### PR TITLE
ROX-9409: removes PROBE_NAME and PROBE_VERSION 

### DIFF
--- a/cmake/modules/libscap.cmake
+++ b/cmake/modules/libscap.cmake
@@ -15,23 +15,6 @@ get_filename_component(DRIVER_CONFIG_DIR ${CMAKE_BINARY_DIR}/driver/src ABSOLUTE
 get_filename_component(LIBSCAP_INCLUDE_DIR ${LIBSCAP_DIR}/userspace/libscap ABSOLUTE)
 set(LIBSCAP_INCLUDE_DIRS ${LIBSCAP_INCLUDE_DIR} ${DRIVER_CONFIG_DIR})
 
-if(CMAKE_SYSTEM_NAME MATCHES "Linux")
-	if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-		set(KBUILD_FLAGS "${FALCOSECURITY_LIBS_DEBUG_FLAGS}")
-	endif()
-
-    if(NOT DEFINED PROBE_VERSION)
-        set(PROBE_VERSION "${SYSDIG_VERSION}")
-    endif()
-    if(NOT DEFINED PROBE_NAME)
-        set(PROBE_NAME "collector")
-    endif()
-
-    if(NOT DEFINED PROBE_DEVICE_NAME)
-        set(PROBE_DEVICE_NAME "sysdig")
-    endif()
-endif()
-
 if(BUILD_USERSPACE)
 	add_subdirectory(${LIBSCAP_DIR}/userspace/libscap ${PROJECT_BINARY_DIR}/libscap)
 elseif(((BUILD_DRIVER) OR (BUILD_BPF)) AND (CMAKE_SYSTEM_NAME MATCHES "Linux"))

--- a/driver/main.c
+++ b/driver/main.c
@@ -815,7 +815,7 @@ static int ppm_open(struct inode *inode, struct file *filp)
 			}
 		}
 		set_bit(PPME_DROP_X, consumer->events_mask);
-		set_bit(PPME_SYSDIGEVENT_E, consumer->events_mask);
+		set_bit(PPME_PLUGINEVENT_E, consumer->events_mask);
 		set_bit(PPME_CONTAINER_E, consumer->events_mask);
 		set_bit(PPME_CONTAINER_X, consumer->events_mask);
 	} else {


### PR DESCRIPTION
In favour of DRIVER_NAME and DRIVER_VERSION used by userspace/libscap/CMakeLists.txt

This will not be upstreamed, since these configuration options exist on upstream already. This will be accompanied by a similar PR in the collector repo, to use these DRIVER_* variables as well. 
