### PR TITLE
Remove unnecessary asserts

### DIFF
--- a/userspace/libscap/scap_procs.c
+++ b/userspace/libscap/scap_procs.c
@@ -107,7 +107,6 @@ int32_t scap_proc_fill_info_from_stats(scap_t *handle, char* procdirname, struct
 	FILE* f = fopen(filename, "r");
 	if(f == NULL)
 	{
-		ASSERT(false);
 		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "open status file %s failed (%s)",
 			 filename, scap_strerror(handle, errno));
 		return SCAP_FAILURE;
@@ -363,7 +362,6 @@ int32_t scap_proc_fill_cgroups(scap_t *handle, struct scap_threadinfo* tinfo, co
 	FILE* f = fopen(filename, "r");
 	if(f == NULL)
 	{
-		ASSERT(false);
 		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "open cgroup file %s failed (%s)",
 			 filename, scap_strerror(handle, errno));
 		return SCAP_FAILURE;


### PR DESCRIPTION
There are two acknowledged exception cases, which are handled inside
falcolibs, but contain an unconditional ASSERT. One happens when reading
information about the cgroup for the process (the process can disappear
in the meantime, leaving the library failing on trying to open a
corresponding procfs entries), another one at reading information about
the process itself (the same story, the process can be already finished
at this point, leaving no procfs entries).

Both errors are valid from the design point of view, and they do not
represent any significant issue, so it doesn't make sense to throw an
ASSERT in the debug mode. Note, that there are more `ASSERTS(false)`,
but only those two are proven to be fine to remove at the moment.