### PR TITLE
Prevent potential double free

### DIFF
--- a/userspace/libscap/scap_procs.c
+++ b/userspace/libscap/scap_procs.c
@@ -1040,6 +1040,7 @@ static int32_t scap_proc_add_from_proc(scap_t* handle, uint32_t tid, char* procd
 			// If res != SCAP_SUCCESS, free thread data for consistency with other locations
 			// in this function where the return value != SCAP_SUCCESS.
 			scap_proc_free(handle, tinfo);
+			free_tinfo = false; // Already free'd by scap_proc_free
 		}
 		/* End StackRox Section */
 	}


### PR DESCRIPTION
This is a very simple PR that fixes a potential double free when we fail to get information from a process while crawling procfs.

Every now and again a process we are crawling might stop running and valgrind will generate a message as follows:

<details>
  <summary>Valgrind log </summary>

```
==11== Invalid free() / delete / delete[] / realloc()
==11==    at 0x4C3882B: free (vg_replace_malloc.c:755)
==11==    by 0x59487D3: scap_proc_add_from_proc (scap_procs.c:915)
==11==    by 0x5948F2C: _scap_proc_scan_proc_dir_impl (scap_procs.c:1012)
==11==    by 0x594908F: scap_proc_scan_proc_dir (scap_procs.c:1060)
==11==    by 0x592B8C3: scap_open_live_int (scap.c:465)
==11==    by 0x592CD6E: scap_open (scap.c:1077)
==11==    by 0x558E5C9: sinsp::open_live_common(unsigned int, scap_mode_t) (sinsp.cpp:503)
==11==    by 0x558E6D8: sinsp::open(unsigned int) (sinsp.cpp:517)
==11==    by 0x558F0B2: sinsp::open(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (sinsp.cpp:724)
==11==    by 0x85498C: collector::SysdigService::Start() (SysdigService.cpp:160)
==11==    by 0x7E7A85: collector::CollectorService::RunForever() (CollectorService.cpp:109)
==11==    by 0x7D756B: main (collector.cpp:407)
==11==  Address 0x29dce6b0 is 0 bytes inside a block of size 17,616 free'd
==11==    at 0x4C3882B: free (vg_replace_malloc.c:755)
==11==    by 0x5949967: scap_proc_free (scap_procs.c:1303)
==11==    by 0x59487C1: scap_proc_add_from_proc (scap_procs.c:907)
==11==    by 0x5948F2C: _scap_proc_scan_proc_dir_impl (scap_procs.c:1012)
==11==    by 0x594908F: scap_proc_scan_proc_dir (scap_procs.c:1060)
==11==    by 0x592B8C3: scap_open_live_int (scap.c:465)
==11==    by 0x592CD6E: scap_open (scap.c:1077)
==11==    by 0x558E5C9: sinsp::open_live_common(unsigned int, scap_mode_t) (sinsp.cpp:503)
==11==    by 0x558E6D8: sinsp::open(unsigned int) (sinsp.cpp:517)
==11==    by 0x558F0B2: sinsp::open(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (sinsp.cpp:724)
==11==    by 0x85498C: collector::SysdigService::Start() (SysdigService.cpp:160)
==11==    by 0x7E7A85: collector::CollectorService::RunForever() (CollectorService.cpp:109)
==11==    by 0x7D756B: main (collector.cpp:407)
==11==  Block was alloc'd at
==11==    at 0x4C3AAFF: calloc (vg_replace_malloc.c:1117)
==11==    by 0x59498FF: scap_proc_alloc (scap_procs.c:1290)
==11==    by 0x594702D: scap_proc_add_from_proc (scap_procs.c:629)
==11==    by 0x5948F2C: _scap_proc_scan_proc_dir_impl (scap_procs.c:1012)
==11==    by 0x594908F: scap_proc_scan_proc_dir (scap_procs.c:1060)
==11==    by 0x592B8C3: scap_open_live_int (scap.c:465)
==11==    by 0x592CD6E: scap_open (scap.c:1077)
==11==    by 0x558E5C9: sinsp::open_live_common(unsigned int, scap_mode_t) (sinsp.cpp:503)
==11==    by 0x558E6D8: sinsp::open(unsigned int) (sinsp.cpp:517)
==11==    by 0x558F0B2: sinsp::open(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (sinsp.cpp:724)
==11==    by 0x85498C: collector::SysdigService::Start() (SysdigService.cpp:160)
==11==    by 0x7E7A85: collector::CollectorService::RunForever() (CollectorService.cpp:109)
==11==    by 0x7D756B: main (collector.cpp:407)
==11==
error reading /host/proc/1 Cannot read sockets (Could not read ipv6 raw sockets ())
```

</details>

Tricking collector to constantly fail by changing [this condition](https://github.com/stackrox/falcosecurity-libs/blob/64168201bbccbb9a215e5898afe8ff16dbaa7066/userspace/libscap/scap_fds.c#L1816) produces the same logs without the change and it stops showing up once the change is applied.
https://github.com/stackrox/falcosecurity-libs/blob/64168201bbccbb9a215e5898afe8ff16dbaa7066/userspace/libscap/scap_fds.c#L1816