### PR TITLE
Rollback environment variable for host root

### DIFF
--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -2687,7 +2687,7 @@ int32_t scap_disable_dynamic_snaplen(scap_t* handle)
 
 const char* scap_get_host_root()
 {
-	char* p = getenv("COLLECTOR_HOST_ROOT");
+	char* p = getenv("SCAP_HOST_ROOT_ENV_VAR_NAME");
 	static char env_str[SCAP_MAX_PATH_SIZE + 1];
 	static bool inited = false;
 	if (! inited) {


### PR DESCRIPTION
This PR rolls back a change were we used the `COLLECTOR_HOST_ROOT` to get the point where the hosts `/` dir was mounted inside collector. Even though it's more work on our end, a more friendly approach would be to leave this variable as is upstream and set it at build time in our own project.