### PR TITLE
Allow configuration of ring buffer depth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 build/
 driver/Makefile
 driver/driver_config.h
+driver/ppm_ringbuffer.h
 *.pyc
 *.config
 *.creator

--- a/driver/CMakeLists.txt
+++ b/driver/CMakeLists.txt
@@ -56,9 +56,14 @@ message(STATUS "Driver schema version ${PPM_SCHEMA_CURRENT_VERSION_MAJOR}.${PPM_
 execute_process(COMMAND git rev-parse HEAD OUTPUT_VARIABLE GIT_COMMIT ERROR_QUIET WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 string(STRIP "${GIT_COMMIT}" GIT_COMMIT)
 
+if(NOT DEFINED RING_BUF_MULTIPLIER)
+	set(RING_BUF_MULTIPLIER 8)
+endif()
+
 configure_file(dkms.conf.in src/dkms.conf)
 configure_file(Makefile.in src/Makefile)
 configure_file(driver_config.h.in src/driver_config.h)
+configure_file(ppm_ringbuffer.h.in src/ppm_ringbuffer.h)
 
 set(DRIVER_SOURCES
 	dynamic_params_table.c
@@ -75,7 +80,6 @@ set(DRIVER_SOURCES
 	ppm_fillers.c
 	ppm_fillers.h
 	ppm_flag_helpers.h
-	ppm_ringbuffer.h
 	ppm_syscall.h
 	syscall_table.c
 	ppm_cputime.c

--- a/driver/ppm_ringbuffer.h.in
+++ b/driver/ppm_ringbuffer.h.in
@@ -14,7 +14,9 @@ or GPL2.txt for full copies of the license.
 #include <linux/types.h>
 #endif
 
-static const __u32 RING_BUF_SIZE = 16 * 1024 * 1024;
+#define RING_BUF_MULTIPLIER ${RING_BUF_MULTIPLIER}
+
+static const __u32 RING_BUF_SIZE = RING_BUF_MULTIPLIER * 1024 * 1024;
 static const __u32 MIN_USERSPACE_READ_SIZE = 128 * 1024;
 
 /*

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -41,7 +41,7 @@ limitations under the License.
 #include "driver_config.h"
 #endif // _WIN32 && CYGWING_AGENT
 #endif // HAS_CAPTURE
-#include "../../driver/ppm_ringbuffer.h"
+#include "ppm_ringbuffer.h"
 #include "scap_savefile.h"
 #include "scap-int.h"
 #if defined(HAS_CAPTURE) && !defined(_WIN32) && !defined(CYGWING_AGENT)

--- a/userspace/libscap/scap_procs.c
+++ b/userspace/libscap/scap_procs.c
@@ -35,7 +35,7 @@ limitations under the License.
 #endif // HAS_CAPTURE
 
 #include "scap.h"
-#include "../../driver/ppm_ringbuffer.h"
+#include "ppm_ringbuffer.h"
 #include "scap-int.h"
 
 #if defined(CYGWING_AGENT) || defined(_WIN32)

--- a/userspace/libscap/scap_udig.c
+++ b/userspace/libscap/scap_udig.c
@@ -28,7 +28,7 @@
 
 #include "scap.h"
 #include "scap-int.h"
-#include "../../driver/ppm_ringbuffer.h"
+#include "ppm_ringbuffer.h"
 
 #define PPM_PORT_STATSD 8125
 

--- a/userspace/libsinsp/table.cpp
+++ b/userspace/libsinsp/table.cpp
@@ -19,7 +19,6 @@ limitations under the License.
 
 #include "sinsp.h"
 #include "sinsp_int.h"
-#include "../../driver/ppm_ringbuffer.h"
 #include "filter.h"
 #include "filter_check_list.h"
 #include "filterchecks.h"


### PR DESCRIPTION
This PR makes the necessary changes to allow for the ring buffer depth to be set at build time. The naming chosen for the multiplier define might not be the best.