### PR TITLE
Giles/remove exe writable for rhel kernels

### DIFF
--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -1965,6 +1965,8 @@ static __always_inline int bpf_accumulate_argv_or_env(struct filler_data *data,
 	return PPM_SUCCESS;
 }
 
+#if LINUX_VERSION_CODE > KERNEL_VERSION(4, 9, 0)
+
 // log(NGROUPS_MAX) = log(65536)
 #define MAX_GROUP_SEARCH_DEPTH 16
 
@@ -2170,6 +2172,7 @@ static __always_inline bool get_exe_writable(struct task_struct *task)
 
 	return false;
 }
+#endif // LINUX_VERSION_CODE > KERNEL_VERSION(4, 9, 0)
 
 FILLER(proc_startupdate, true)
 {
@@ -2690,6 +2693,7 @@ FILLER(execve_family_flags, true)
 	task = (struct task_struct *)bpf_get_current_task();
 	cred = (struct cred *)_READ(task->cred);
 
+#if LINUX_VERSION_CODE > KERNEL_VERSION(4, 9, 0)
 	/*
 	 * exe_writable
 	 */
@@ -2698,6 +2702,7 @@ FILLER(execve_family_flags, true)
 	{
 		flags |= PPM_EXE_WRITABLE;
 	}
+#endif // LINUX_VERSION_CODE > KERNEL_VERSION(4, 9, 0)
 
 	// write all additional flags for execve family here...
 


### PR DESCRIPTION
Hides writable exe logic behind linux version guard for older kernels.