### PR TITLE
update(userspace/libscap): makes BPF_PROGS_MAX configurable at compile time

### DIFF
--- a/userspace/libscap/CMakeLists.txt
+++ b/userspace/libscap/CMakeLists.txt
@@ -62,6 +62,10 @@ if(NOT DEFINED SCAP_HOST_ROOT_ENV_VAR_NAME)
 endif()
 add_definitions(-DSCAP_HOST_ROOT_ENV_VAR_NAME="${SCAP_HOST_ROOT_ENV_VAR_NAME}")
 
+if (DEFINED SCAP_BPF_PROGS_MAX)
+	add_definitions(-DBPF_PROGS_MAX=${SCAP_BPF_PROGS_MAX})
+endif()
+
 if(CYGWIN)
 include_directories("${WIN_HAL_INCLUDE}")
 endif()

--- a/userspace/libscap/scap-int.h
+++ b/userspace/libscap/scap-int.h
@@ -71,7 +71,10 @@ inline const char *gzerror(FILE *F, int *E) {*E = ferror(F); return "error readi
 //
 // ebpf defs
 //
+#ifndef BPF_PROGS_MAX
 #define BPF_PROGS_MAX 128
+#endif
+
 #define BPF_MAPS_MAX 32
 
 //


### PR DESCRIPTION
Allows us to increase the limit for the custom probe (which requires around 240 programs in total, including fillers)