### PR TITLE
Reinstates g_bpf_drop_syscalls usage

### DIFF
--- a/userspace/libscap/scap_bpf.c
+++ b/userspace/libscap/scap_bpf.c
@@ -805,7 +805,7 @@ static int32_t populate_syscall_table_map(scap_t *handle)
 	for(j = 0; j < SYSCALL_TABLE_SIZE; ++j)
 	{
 		const struct syscall_evt_pair *p = &g_syscall_table[j];
-		if (!handle->syscalls_of_interest[j])
+		if (!handle->syscalls_of_interest[j] || g_bpf_drop_syscalls[j])
 		{
 			p = &uninterested_pair;
 		}


### PR DESCRIPTION
To fix the performance regression on RHEL-7 this reinstates the use of g_bpf_drop_syscalls to ensure that only the syscalls we want to trace are picked up by the sys_enter/sys_exit probes. 

The alternative is to set sinsp::m_ppm_sc_of_interest manually, which should then eventually propagate to scap::syscalls_of_interest, but a confusing thread-based segfault was encountered during testing. This quick fix may be reverted once the segfault has been identified and fixed.
