### PR TITLE
Cherry-picked commit fixing missing process arguments

### DIFF
--- a/driver/bpf/filler_helpers.h
+++ b/driver/bpf/filler_helpers.h
@@ -849,7 +849,8 @@ static __always_inline int __bpf_val_to_ring(struct filler_data *data,
 		break;
 	}
 	case PT_BYTEBUF: {
-		if (val!=0 && val_len) {
+		if (data->curarg_already_on_frame || (val && val_len))  
+		{
 			len = val_len;
 
 			if (enforce_snaplen) {


### PR DESCRIPTION
Due to a seemingly minor change to the helper for writing data to the buffer, process args were dropped by the eBPF probes. This is fixed upstream, and this PR cherry-picks the relevant commit to fix the issue.