### PR TITLE
ROX-11830 Use valijson from the system when requested.

### DIFF
--- a/cmake/modules/Findvalijson.cmake
+++ b/cmake/modules/Findvalijson.cmake
@@ -1,0 +1,35 @@
+#
+# Copyright (C) 2022 The Falco Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This module is used to find where the valijson headers are installed
+# on the system. This is required up to v0.6, since package config
+# files are not provided. This is fixed in master though, and this
+# file shall be automatically ignored for later versions.
+
+find_path(VALIJSON_INCLUDE NAMES valijson/validator.hpp validator.hpp)
+
+if (VALIJSON_INCLUDE)
+    if (NOT valijson_FIND_QUIETLY)
+        message(STATUS "Found valijson: include: ${VALIJSON_INCLUDE}.")
+    endif()
+else()
+    if (valijson_FIND_REQUIRED)
+        message(FATAL_ERROR "Required component valijson missing.")
+    endif()
+    if (NOT valijson_FIND_QUIETLY)
+        message(WARNING "Valijson not found.")
+    endif()
+endif()

--- a/cmake/modules/valijson.cmake
+++ b/cmake/modules/valijson.cmake
@@ -14,8 +14,13 @@
 #
 # Valijson (https://github.com/tristanpenman/valijson/)
 #
+
+option(USE_BUNDLED_VALIJSON "Enable building of the bundled valijson" ${USE_BUNDLED_DEPS})
+
 if(VALIJSON_INCLUDE)
 	# we already have valijson
+elseif(NOT USE_BUNDLED_VALIJSON)
+	find_package(valijson REQUIRED)
 else()
 	set(VALIJSON_SRC "${PROJECT_BINARY_DIR}/valijson-prefix/src/valijson")
 	set(VALIJSON_INCLUDE "${VALIJSON_SRC}/include")


### PR DESCRIPTION
By default, the valijson library is compiled from sources fetched from internet (tarball) as a side-effect during the build.
We want it to observe the USE_BUNDLED_DEPS directive and search for a pre-installed version of valijson when USE_BUNDLED_DEPS=FALSE