### PR TITLE
Ensure cgroups are read from /proc consistently

### DIFF
--- a/userspace/libscap/scap_procs.c
+++ b/userspace/libscap/scap_procs.c
@@ -490,6 +490,12 @@ int32_t scap_proc_fill_cgroups(scap_t *handle, struct scap_threadinfo* tinfo, co
 			{
 				cgroup = subsys_list;
 				subsys_list = default_subsys_list; // force-set a default subsys list
+
+				size_t cgroup_len = strlen(cgroup);
+				if (cgroup_len != 0 && cgroup[cgroup_len - 1] == '\n')
+				{
+					cgroup[cgroup_len - 1] = '\0';
+				}
 			} else
 			{
 				// skip cgroups like this:


### PR DESCRIPTION
When `cgroups` are read from `/proc`, depending on what cgroup version is used, the final string could be left with a line end. This change makes this behavior consistent by always removing the line end.

This situation is particularly troublesome when a system running cgroups v2 also uses a non-systemd docker, because this check will always fail for the strings of format `/0123456789abcdef0123456789abcdef0123456789abdef0123456789abdef01\n`: https://github.com/stackrox/falcosecurity-libs/blob/b781908207733d822fb82b44e5ebf71f9414fd62/userspace/libsinsp/container_engine/docker/docker_linux.cpp#L28

This change will be tested on stackrox/collector#906