### PR TITLE
Correct or disable asserts

### DIFF
--- a/userspace/libscap/linux/scap_fds.c
+++ b/userspace/libscap/linux/scap_fds.c
@@ -721,7 +721,7 @@ int32_t scap_fd_read_ipv4_sockets_from_proc_fs(const char *dir, int l4proto, sca
 	f = fopen(dir, "r");
 	if(NULL == f)
 	{
-		ASSERT(false);
+		/*ASSERT(false);*/
 		free(scan_buf);
 		return scap_errprintf(error, errno, "Could not open ipv4 sockets dir %s", dir);
 	}

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -2290,7 +2290,7 @@ void sinsp_parser::parse_dirfd(sinsp_evt *evt, char* name, int64_t dirfd, OUT st
 
 		if(evt->m_fdinfo == NULL)
 		{
-			ASSERT(false);
+			SINSP_ERROR("Failed to find dirfd %d", dirfd);
 			*sdir = "<UNKNOWN>";
 		}
 		else
@@ -3285,7 +3285,13 @@ void sinsp_parser::parse_connect_exit(sinsp_evt *evt)
 		// This happens for socket types that we don't support, so we have the assertion
 		// to make sure that this is not a type of socket that we support.
 		//
-		ASSERT(!(evt->m_fdinfo->is_unix_socket() || evt->m_fdinfo->is_ipv4_socket()));
+		// There will also be no address if the retval is different from
+		// success, e.g. SE_EINPROGRESS.
+		ASSERT(!(
+			retval == 0 &&
+			(evt->m_fdinfo->is_unix_socket() ||
+			evt->m_fdinfo->is_ipv4_socket())
+		));
 		return;
 	}
 


### PR DESCRIPTION
parse_connect_exit was apparenlly missing where an exit event may come without a proper socket due to EINPROGRESS. The reason for other two asserts are not clear for me, but since the one in scap_fds rarely happens, it's disabled, but the one in parse_dirfd is pretty stable, so it's only downgraded in logging.