### PR TITLE
Adds ppc64le to driver build checks

### DIFF
--- a/driver/CMakeLists.txt
+++ b/driver/CMakeLists.txt
@@ -11,7 +11,8 @@ project(driver)
 set(TARGET_ARCH ${CMAKE_HOST_SYSTEM_PROCESSOR})
 if((NOT TARGET_ARCH STREQUAL "x86_64") AND
    (NOT TARGET_ARCH STREQUAL "aarch64") AND
-   (NOT TARGET_ARCH STREQUAL "s390x"))
+   (NOT TARGET_ARCH STREQUAL "s390x") AND
+   (NOT TARGET_ARCH STREQUAL "ppc64le"))
 	message(WARNING "Target architecture not officially supported by our drivers!")
 else()
     # Load current kernel version
@@ -20,6 +21,7 @@ else()
     message(STATUS  "Kernel version: ${UNAME_RESULT}")
 
     # Check minimum kernel version
+    set(kmod_min_kver_map_ppc64le 2.6)
     set(kmod_min_kver_map_x86_64 2.6)
     set(kmod_min_kver_map_aarch64 3.16)
     set(kmod_min_kver_map_s390x 2.6)


### PR DESCRIPTION
To fix the downstream builds, ppc64le is added as a supported architecture