### PR TITLE
Silence missing BPF program error

### DIFF
--- a/userspace/libpman/src/maps.c
+++ b/userspace/libpman/src/maps.c
@@ -144,9 +144,6 @@ static int add_bpf_program_to_tail_table(int tail_table_fd, const char* bpf_prog
 	bpf_prog = bpf_object__find_program_by_name(g_state.skel->obj, bpf_prog_name);
 	if(!bpf_prog)
 	{
-		snprintf(error_message, MAX_ERROR_MESSAGE_LEN, "unable to find BPF program '%s'", bpf_prog_name);
-		pman_print_error((const char*)error_message);
-
 		/*
 		 * It's not a hard failure, as programs could be excluded from the
 		 * build. There is no need to close the file descriptor yet, so return


### PR DESCRIPTION
It's not in fact an error, as we need to exclude certain progs from the probe. The present of a loud error can be confusing and interfere with troubleshooting.