### PR TITLE
Remove uname checks in driver builds

### DIFF
--- a/driver/CMakeLists.txt
+++ b/driver/CMakeLists.txt
@@ -8,28 +8,6 @@
 cmake_minimum_required(VERSION 2.8.5)
 project(driver)
 
-set(TARGET_ARCH ${CMAKE_HOST_SYSTEM_PROCESSOR})
-if((NOT TARGET_ARCH STREQUAL "x86_64") AND
-   (NOT TARGET_ARCH STREQUAL "aarch64") AND
-   (NOT TARGET_ARCH STREQUAL "s390x") AND
-   (NOT TARGET_ARCH STREQUAL "ppc64le"))
-	message(WARNING "Target architecture not officially supported by our drivers!")
-else()
-    # Load current kernel version
-    execute_process(COMMAND uname -r OUTPUT_VARIABLE UNAME_RESULT OUTPUT_STRIP_TRAILING_WHITESPACE)
-    string(REGEX MATCH "[0-9]+.[0-9]+" LINUX_KERNEL_VERSION ${UNAME_RESULT})
-    message(STATUS  "Kernel version: ${UNAME_RESULT}")
-
-    # Check minimum kernel version
-    set(kmod_min_kver_map_ppc64le 2.6)
-    set(kmod_min_kver_map_x86_64 2.6)
-    set(kmod_min_kver_map_aarch64 3.16)
-    set(kmod_min_kver_map_s390x 2.6)
-    if (LINUX_KERNEL_VERSION VERSION_LESS "${kmod_min_kver_map_${TARGET_ARCH}}")
-        message(WARNING "[KMOD] To run this driver you need a Linux kernel version >= ${kmod_min_kver_map_${TARGET_ARCH}} but actual kernel version is: ${UNAME_RESULT}")
-    endif()
-endif()
-
 option(BUILD_DRIVER "Build the driver on Linux" ON)
 option(ENABLE_DKMS "Enable DKMS on Linux" ON)
 

--- a/driver/bpf/CMakeLists.txt
+++ b/driver/bpf/CMakeLists.txt
@@ -8,14 +8,6 @@
 option(BUILD_BPF "Build the BPF driver on Linux" OFF)
 
 if(BUILD_BPF)
-	# Check minimum kernel version
-	set(bpf_min_kver_map_x86_64 4.14)
-	set(bpf_min_kver_map_aarch64 4.17)
-	set(bpf_min_kver_map_s390x 5.5)
-	if (LINUX_KERNEL_VERSION VERSION_LESS ${bpf_min_kver_map_${TARGET_ARCH}})
-		message(WARNING "[BPF] To run this driver you need a Linux kernel version >= ${bpf_min_kver_map_${TARGET_ARCH}} but actual kernel version is: ${UNAME_RESULT}")
-	endif()
-
 	add_custom_target(bpf ALL
 		COMMAND make
 		COMMAND "${CMAKE_COMMAND}" -E copy_if_different probe.o "${CMAKE_CURRENT_BINARY_DIR}"


### PR DESCRIPTION
Due to problems with downstream builds, various checks have been removed. These might be reinstated post-release, but for simplicity they are simply taken out of the builds.