### PR TITLE
modern_bpf: Fix connect_x prog

### DIFF
--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/connect.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/connect.bpf.c
@@ -6,6 +6,7 @@
  */
 
 #include <helpers/interfaces/variable_size_event.h>
+#include <asm/errno.h>
 
 /*=============================== ENTER EVENT ===========================*/
 
@@ -73,7 +74,7 @@ int BPF_PROG(connect_x,
 
 	/* Parameter 2: tuple (type: PT_SOCKTUPLE) */
 	/* We need a valid sockfd to extract source data.*/
-	if(ret == 0)
+	if(ret == 0 || ret == -EINPROGRESS)
 	{
 		auxmap__store_socktuple_param(auxmap, socket_fd, OUTBOUND);
 	}


### PR DESCRIPTION
The modern probe connect_x behaviour is different from the original ebpf in how it handles return value. The new one doesn't extract arguments if retvalue indicates failure, where the original one didn't do such distinction.

The problem is that it still makes sense to extract arguments in case if the failure is only EINPROGRESS.