### PR TITLE
Fix extract__loginuid for COS

### DIFF
--- a/driver/modern_bpf/helpers/extract/extract_from_kernel.h
+++ b/driver/modern_bpf/helpers/extract/extract_from_kernel.h
@@ -592,15 +592,19 @@ static __always_inline u32 exctract__tty(struct task_struct *task)
  */
 static __always_inline void extract__loginuid(struct task_struct *task, u32 *loginuid)
 {
+	*loginuid = -1;
 	if (bpf_core_field_exists(task->loginuid))
 	{
 		READ_TASK_FIELD_INTO(loginuid, task, loginuid.val);
 	}
 	else
 	{
-		struct task_struct___cos *task_cos = (void *) task;
+		struct task_struct___cos *task_cos = (void *)task;
 
-		READ_TASK_FIELD_INTO(loginuid, task_cos, audit->loginuid.val);
+		if(bpf_core_field_exists(task_cos->audit->loginuid))
+		{
+			READ_TASK_FIELD_INTO(loginuid, task_cos, audit, loginuid.val);
+		}
 	}
 }
 

--- a/driver/modern_bpf/helpers/extract/extract_from_kernel.h
+++ b/driver/modern_bpf/helpers/extract/extract_from_kernel.h
@@ -26,6 +26,23 @@ enum capability_type
 	CAP_EFFECTIVE = 2,
 };
 
+/* COS kernels handle audit field differently, see [1]. To support both
+ * versions define COS subset of task_struct with a flavor suffix (which will
+ * be ignored during relocation matching [2]).
+ *
+ * [1]: https://chromium.googlesource.com/chromiumos/third_party/kernel/+/096925a44076ba5c52faa84d255a847130ff341e%5E%21/#F2
+ * [2]: https://git.kernel.org/pub/scm/linux/kernel/git/bpf/bpf-next.git/tree/tools/lib/bpf/libbpf.c#n5347
+ */
+struct audit_task_info {
+	kuid_t			loginuid;
+	unsigned int		sessionid;
+	struct audit_context	*ctx;
+};
+
+struct task_struct___cos {
+	struct audit_task_info		*audit;
+} __attribute__((preserve_access_index));
+
 /* All the functions that are called in bpf to extract parameters
  * start with the `extract` prefix.
  */
@@ -575,7 +592,16 @@ static __always_inline u32 exctract__tty(struct task_struct *task)
  */
 static __always_inline void extract__loginuid(struct task_struct *task, u32 *loginuid)
 {
-	READ_TASK_FIELD_INTO(loginuid, task, loginuid.val);
+	if (bpf_core_field_exists(task->loginuid))
+	{
+		READ_TASK_FIELD_INTO(loginuid, task, loginuid.val);
+	}
+	else
+	{
+		struct task_struct___cos *task_cos = (void *) task;
+
+		READ_TASK_FIELD_INTO(loginuid, task_cos, audit->loginuid.val);
+	}
 }
 
 /////////////////////////


### PR DESCRIPTION
COS kernels have task_struct that differs from the vanilla one in regards how audit information is stored, loginuid is present in an intermediate structure audit_task_info [[1]]. This mean regular CO-RE read will not pass verifier on COS kernels. To address it, check the field presence first, before extracting the value. Note, it's important that the condition is formulated this way -- the first branch should be an existing one, otherwise it will be removed as a dead code and no comparison will be made [[2]].

[1]: https://chromium.googlesource.com/chromiumos/third_party/kernel/+/096925a44076ba5c52faa84d255a847130ff341e%5E%21/#F2
[2]: https://nakryiko.com/posts/bpf-core-reference-guide/#handling-incompatible-field-and-type-changes