### PR TITLE
ROX-18856: [co-re] pick a fix for verifier error on recent kernels (getsockopt)

### DIFF
--- a/driver/modern_bpf/helpers/store/auxmap_store_params.h
+++ b/driver/modern_bpf/helpers/store/auxmap_store_params.h
@@ -931,7 +931,7 @@ static __always_inline void auxmap__store_sockopt_param(struct auxiliary_map *au
 	/* We use a signed int because in some case we have to convert it to a negative value. */
 	s32 val32 = 0;
 	u64 val64 = 0;
-	struct __kernel_timex_timeval tv;
+	struct modern_bpf__kernel_timex_timeval tv;
 	u16 total_size_to_push = sizeof(u8); /* 1 byte for the PPM type. */
 
 	/* Levels different from `SOL_SOCKET` are not supported
@@ -960,7 +960,7 @@ static __always_inline void auxmap__store_sockopt_param(struct auxiliary_map *au
 	case SO_SNDTIMEO_OLD:
 	case SO_SNDTIMEO_NEW:
 		push__u8(auxmap->data, &auxmap->payload_pos, PPM_SOCKOPT_IDX_TIMEVAL);
-		bpf_probe_read_user((void *)&tv, bpf_core_type_size(struct __kernel_timex_timeval), (void *)optval);
+		bpf_probe_read_user((void *)&tv, sizeof(tv), (void *)optval);
 		push__u64(auxmap->data, &auxmap->payload_pos, tv.tv_sec * SEC_FACTOR + tv.tv_usec * USEC_FACTOR);
 		total_size_to_push += sizeof(u64);
 		break;

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/clone3.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/clone3.bpf.c
@@ -191,11 +191,15 @@ int BPF_PROG(t1_clone3_x,
 
 	/* Parameter 16: flags (type: PT_FLAGS32) */
 	/* the `clone_args` struct is defined since kernel version 5.3 */
-	unsigned long cl_args_pointer = extract__syscall_argument(regs, 0);
-	struct clone_args cl_args = {0};
-	bpf_probe_read_user((void *)&cl_args, bpf_core_type_size(struct clone_args), (void *)cl_args_pointer);
-	unsigned long flags = cl_args.flags;
-	auxmap__store_u32_param(auxmap, (u32)extract__clone_flags(task, flags));
+	unsigned long flags = 0;
+	if(bpf_core_type_exists(struct clone_args))
+	{
+		unsigned long cl_args_pointer = extract__syscall_argument(regs, 0);
+		struct clone_args cl_args = {0};
+		bpf_probe_read_user((void *)&cl_args, bpf_core_type_size(struct clone_args), (void *)cl_args_pointer);
+		flags = extract__clone_flags(task, cl_args.flags);
+	}
+	auxmap__store_u32_param(auxmap, (u32)flags);
 
 	/* Parameter 17: uid (type: PT_UINT32) */
 	u32 euid = 0;

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/ppoll.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/ppoll.bpf.c
@@ -35,10 +35,21 @@ int BPF_PROG(ppoll_e,
 	auxmap__store_fdlist_param(auxmap, fds_pointer, nfds, REQUESTED_EVENTS);
 
 	/* Parameter 2: timeout (type: PT_RELTIME) */
-	struct __kernel_timespec ts = {0};
+	u64 nanosec = 0;
 	unsigned long ts_pointer = extract__syscall_argument(regs, 2);
-	bpf_probe_read_user(&ts, bpf_core_type_size(struct __kernel_timespec), (void *)ts_pointer);
-	auxmap__store_u64_param(auxmap, ((u64)ts.tv_sec) * SECOND_TO_NS + ts.tv_nsec);
+	if(bpf_core_type_exists(struct __kernel_timespec))
+	{
+		struct __kernel_timespec ts = {0};
+		bpf_probe_read_user(&ts, bpf_core_type_size(struct __kernel_timespec), (void *)ts_pointer);
+		nanosec = ((u64)ts.tv_sec) * SECOND_TO_NS + ts.tv_nsec;
+	}
+	else
+	{
+		struct modern_bpf__kernel_timespec ts = {0};
+		bpf_probe_read_user(&ts, sizeof(ts), (void *)ts_pointer);
+		nanosec = ((u64)ts.tv_sec) * SECOND_TO_NS + ts.tv_nsec;
+	}
+	auxmap__store_u64_param(auxmap, nanosec);
 
 	/* Parameter 3: sigmask (type: PT_SIGSET) */
 	long unsigned int sigmask[1] = {0};


### PR DESCRIPTION
Proper handling of TCP asynchronous connections requires the use of getsockopt, which has a verifier issue on recent kernels. Cherry-pick one upstream commit.