### PR TITLE
Allow disabling timestamps in the inspector log messages

### DIFF
--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -1964,6 +1964,11 @@ void sinsp::set_min_log_severity(sinsp_logger::severity sev)
 	g_logger.set_severity(sev);
 }
 
+void sinsp::disable_log_timestamps()
+{
+	g_logger.disable_timestamps();
+}
+
 sinsp_evttables* sinsp::get_event_info_tables()
 {
 	return &g_infotables;

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -388,6 +388,11 @@ public:
 	void set_min_log_severity(sinsp_logger::severity sev);
 
 	/*!
+	 * \brief Remove timestamps from the generated log messages.
+	 */
+	void disable_log_timestamps();
+
+	/*!
 	 * \brief set whether the library will automatically purge the threadtable
 	 *        at specific times. If not, client is responsible for thread lifetime
 	 *        management. If invoked, then the purge interval and thread timeout change


### PR DESCRIPTION
Small change so logs generated by the inspector don't add timestamps. This is useful when using the callback method, which can be piped into an external logging mechanism and should be provided with a more raw message.