### PR TITLE
ROX-20541: Fix/build 6.6

### DIFF
--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -2993,7 +2993,12 @@ FILLER(execve_family_flags, true)
 	struct timespec64 time = {0};
 
 	/* Parameter 25: exe_file ctime (last status change time, epoch value in nanoseconds) (type: PT_ABSTIME) */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 0)
+	time = _READ(inode->__i_ctime);
+	time.tv_nsec = time.tv_nsec & ~I_CTIME_QUERIED; // See https://elixir.bootlin.com/linux/v6.6-rc1/source/include/linux/fs.h#L1544
+#else
 	time = _READ(inode->i_ctime);
+#endif
 	res = bpf_val_to_ring_type(data, bpf_epoch_ns_from_time(time), PT_ABSTIME);
 	CHECK_RES(res);
 
@@ -6710,7 +6715,12 @@ FILLER(sched_prog_exec_4, false)
 	struct timespec64 time = {0};
 
 	/* Parameter 25: exe_file ctime (last status change time, epoch value in nanoseconds) (type: PT_ABSTIME) */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 0)
+	time = _READ(inode->__i_ctime);
+	time.tv_nsec = time.tv_nsec & ~I_CTIME_QUERIED; // See https://elixir.bootlin.com/linux/v6.6-rc1/source/include/linux/fs.h#L1544
+#else
 	time = _READ(inode->i_ctime);
+#endif
 	res = bpf_val_to_ring_type(data, bpf_epoch_ns_from_time(time), PT_ABSTIME);
 	CHECK_RES(res);
 

--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -2995,7 +2995,6 @@ FILLER(execve_family_flags, true)
 	/* Parameter 25: exe_file ctime (last status change time, epoch value in nanoseconds) (type: PT_ABSTIME) */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 0)
 	time = _READ(inode->__i_ctime);
-	time.tv_nsec = time.tv_nsec & ~I_CTIME_QUERIED; // See https://elixir.bootlin.com/linux/v6.6-rc1/source/include/linux/fs.h#L1544
 #else
 	time = _READ(inode->i_ctime);
 #endif
@@ -6717,7 +6716,6 @@ FILLER(sched_prog_exec_4, false)
 	/* Parameter 25: exe_file ctime (last status change time, epoch value in nanoseconds) (type: PT_ABSTIME) */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 0)
 	time = _READ(inode->__i_ctime);
-	time.tv_nsec = time.tv_nsec & ~I_CTIME_QUERIED; // See https://elixir.bootlin.com/linux/v6.6-rc1/source/include/linux/fs.h#L1544
 #else
 	time = _READ(inode->i_ctime);
 #endif

--- a/driver/modern_bpf/definitions/missing_definitions.h
+++ b/driver/modern_bpf/definitions/missing_definitions.h
@@ -561,13 +561,6 @@
 #define SEEK_MAX SEEK_HOLE
 
 //////////////////////////
-// ctime flags
-//////////////////////////
-
-/* `include/linux/fs.h` from kernel source tree. */
-#define I_CTIME_QUERIED		(1L<<30)
-
-//////////////////////////
 // flock flags
 //////////////////////////
 

--- a/driver/modern_bpf/definitions/missing_definitions.h
+++ b/driver/modern_bpf/definitions/missing_definitions.h
@@ -561,6 +561,13 @@
 #define SEEK_MAX SEEK_HOLE
 
 //////////////////////////
+// ctime flags
+//////////////////////////
+
+/* `include/linux/fs.h` from kernel source tree. */
+#define I_CTIME_QUERIED		(1L<<30)
+
+//////////////////////////
 // flock flags
 //////////////////////////
 

--- a/driver/modern_bpf/definitions/struct_flavors.h
+++ b/driver/modern_bpf/definitions/struct_flavors.h
@@ -58,4 +58,75 @@ struct modern_bpf__kernel_timex_timeval
 	long long int tv_usec;
 };
 
+struct inode___v6_6 {
+	umode_t i_mode;
+	short unsigned int i_opflags;
+	kuid_t i_uid;
+	kgid_t i_gid;
+	unsigned int i_flags;
+	struct posix_acl *i_acl;
+	struct posix_acl *i_default_acl;
+	const struct inode_operations *i_op;
+	struct super_block *i_sb;
+	struct address_space *i_mapping;
+	void *i_security;
+	long unsigned int i_ino;
+	union {
+		const unsigned int i_nlink;
+		unsigned int __i_nlink;
+	};
+	dev_t i_rdev;
+	loff_t i_size;
+	struct timespec64 i_atime;
+	struct timespec64 i_mtime;
+	struct timespec64 __i_ctime;
+	spinlock_t i_lock;
+	short unsigned int i_bytes;
+	u8 i_blkbits;
+	u8 i_write_hint;
+	blkcnt_t i_blocks;
+	long unsigned int i_state;
+	struct rw_semaphore i_rwsem;
+	long unsigned int dirtied_when;
+	long unsigned int dirtied_time_when;
+	struct hlist_node i_hash;
+	struct list_head i_io_list;
+	struct bdi_writeback *i_wb;
+	int i_wb_frn_winner;
+	u16 i_wb_frn_avg_time;
+	u16 i_wb_frn_history;
+	struct list_head i_lru;
+	struct list_head i_sb_list;
+	struct list_head i_wb_list;
+	union {
+		struct hlist_head i_dentry;
+		struct callback_head i_rcu;
+	};
+	atomic64_t i_version;
+	atomic64_t i_sequence;
+	atomic_t i_count;
+	atomic_t i_dio_count;
+	atomic_t i_writecount;
+	atomic_t i_readcount;
+	union {
+		const struct file_operations *i_fop;
+		void (*free_inode)(struct inode *);
+	};
+	struct file_lock_context *i_flctx;
+	struct address_space i_data;
+	struct list_head i_devices;
+	union {
+		struct pipe_inode_info *i_pipe;
+		struct cdev *i_cdev;
+		char *i_link;
+		unsigned int i_dir_seq;
+	};
+	__u32 i_generation;
+	__u32 i_fsnotify_mask;
+	struct fsnotify_mark_connector *i_fsnotify_marks;
+	struct fscrypt_info *i_crypt_info;
+	struct fsverity_info *i_verity_info;
+	void *i_private;
+};
+
 #endif /* __STRUCT_FLAVORS_H__ */

--- a/driver/modern_bpf/programs/attached/events/sched_process_exec.bpf.c
+++ b/driver/modern_bpf/programs/attached/events/sched_process_exec.bpf.c
@@ -203,7 +203,16 @@ int BPF_PROG(t1_sched_p_exec,
 
 	/* Parameter 25: exe_file ctime (last status change time, epoch value in nanoseconds) (type: PT_ABSTIME) */
 	struct timespec64 time = { 0, 0 };
-	BPF_CORE_READ_INTO(&time, exe_inode, i_ctime);
+	if(bpf_core_type_exists(struct inode))
+	{
+		BPF_CORE_READ_INTO(&time, exe_inode, i_ctime);
+	}
+	else
+	{
+		struct inode___v6_6 *exe_inode_v6_6 = (void *)exe_inode;
+		BPF_CORE_READ_INTO(&time, exe_inode_v6_6, __i_ctime);
+		time.tv_nsec = time.tv_nsec & ~I_CTIME_QUERIED;
+	}
 	auxmap__store_u64_param(auxmap, extract__epoch_ns_from_time(time));
 
 	/* Parameter 26: exe_file mtime (last modification time, epoch value in nanoseconds) (type: PT_ABSTIME) */

--- a/driver/modern_bpf/programs/attached/events/sched_process_exec.bpf.c
+++ b/driver/modern_bpf/programs/attached/events/sched_process_exec.bpf.c
@@ -211,7 +211,6 @@ int BPF_PROG(t1_sched_p_exec,
 	{
 		struct inode___v6_6 *exe_inode_v6_6 = (void *)exe_inode;
 		BPF_CORE_READ_INTO(&time, exe_inode_v6_6, __i_ctime);
-		time.tv_nsec = time.tv_nsec & ~I_CTIME_QUERIED;
 	}
 	auxmap__store_u64_param(auxmap, extract__epoch_ns_from_time(time));
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/execve.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/execve.bpf.c
@@ -275,7 +275,6 @@ int BPF_PROG(t1_execve_x,
 	{
 		struct inode___v6_6 *exe_inode_v6_6 = (void *)exe_inode;
 		BPF_CORE_READ_INTO(&time, exe_inode_v6_6, __i_ctime);
-		time.tv_nsec = time.tv_nsec & ~I_CTIME_QUERIED;
 	}
 	auxmap__store_u64_param(auxmap, extract__epoch_ns_from_time(time));
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/execve.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/execve.bpf.c
@@ -267,7 +267,16 @@ int BPF_PROG(t1_execve_x,
 
 	/* Parameter 25: exe_file ctime (last status change time, epoch value in nanoseconds) (type: PT_ABSTIME) */
 	struct timespec64 time = { 0, 0 };
-	BPF_CORE_READ_INTO(&time, exe_inode, i_ctime);
+	if(bpf_core_type_exists(struct inode))
+	{
+		BPF_CORE_READ_INTO(&time, exe_inode, i_ctime);
+	}
+	else
+	{
+		struct inode___v6_6 *exe_inode_v6_6 = (void *)exe_inode;
+		BPF_CORE_READ_INTO(&time, exe_inode_v6_6, __i_ctime);
+		time.tv_nsec = time.tv_nsec & ~I_CTIME_QUERIED;
+	}
 	auxmap__store_u64_param(auxmap, extract__epoch_ns_from_time(time));
 
 	/* Parameter 26: exe_file mtime (last modification time, epoch value in nanoseconds) (type: PT_ABSTIME) */

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/execveat.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/execveat.bpf.c
@@ -284,7 +284,16 @@ int BPF_PROG(t1_execveat_x,
 
 	/* Parameter 25: exe_file ctime (last status change time, epoch value in nanoseconds) (type: PT_ABSTIME) */
 	struct timespec64 time = { 0, 0 };
-	BPF_CORE_READ_INTO(&time, exe_inode, i_ctime);
+	if(bpf_core_type_exists(struct inode))
+	{
+		BPF_CORE_READ_INTO(&time, exe_inode, i_ctime);
+	}
+	else
+	{
+		struct inode___v6_6 *exe_inode_v6_6 = (void *)exe_inode;
+		BPF_CORE_READ_INTO(&time, exe_inode_v6_6, __i_ctime);
+		time.tv_nsec = time.tv_nsec & ~I_CTIME_QUERIED;
+	}
 	auxmap__store_u64_param(auxmap, extract__epoch_ns_from_time(time));
 
 	/* Parameter 26: exe_file mtime (last modification time, epoch value in nanoseconds) (type: PT_ABSTIME) */

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/execveat.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/execveat.bpf.c
@@ -292,7 +292,6 @@ int BPF_PROG(t1_execveat_x,
 	{
 		struct inode___v6_6 *exe_inode_v6_6 = (void *)exe_inode;
 		BPF_CORE_READ_INTO(&time, exe_inode_v6_6, __i_ctime);
-		time.tv_nsec = time.tv_nsec & ~I_CTIME_QUERIED;
 	}
 	auxmap__store_u64_param(auxmap, extract__epoch_ns_from_time(time));
 

--- a/driver/ppm_fillers.c
+++ b/driver/ppm_fillers.c
@@ -1376,8 +1376,15 @@ cgroups_error:
 				 * During kernel versions `i_ctime` changed from `struct timespec` to `struct timespec64`
 				 * but fields names should be always the same.
 				 */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 0)
+				{
+					struct timespec64 inode_ctime;
+					inode_ctime = inode_get_ctime(file_inode(exe_file));
+					ctime = inode_ctime.tv_sec * (uint64_t) 1000000000 + inode_ctime.tv_nsec;
+				}
+#else
 				ctime = file_inode(exe_file)->i_ctime.tv_sec * (uint64_t) 1000000000 + file_inode(exe_file)->i_ctime.tv_nsec;
-
+#endif
 				/* Support exe_file mtime 
 				 * During kernel versions `i_mtime` changed from `struct timespec` to `struct timespec64`
 				 * but fields names should be always the same.
@@ -7359,7 +7366,15 @@ cgroups_error:
 			 * During kernel versions `i_ctime` changed from `struct timespec` to `struct timespec64`
 			 * but fields names should be always the same.
 			 */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 0)
+			{
+				struct timespec64 inode_ctime;
+				inode_ctime = inode_get_ctime(file_inode(exe_file));
+				ctime = inode_ctime.tv_sec * (uint64_t) 1000000000 + inode_ctime.tv_nsec;
+			}
+#else
 			ctime = file_inode(exe_file)->i_ctime.tv_sec * (uint64_t) 1000000000 + file_inode(exe_file)->i_ctime.tv_nsec;
+#endif
 
 			/* Support exe_file mtime 
 			 * During kernel versions `i_mtime` changed from `struct timespec` to `struct timespec64`


### PR DESCRIPTION
inode->c_time was renamed to push towards using the getters (we still don't): https://github.com/torvalds/linux/commit/13bc24457850583a2e7203ded05b7209ab4bc5ef

Cherry-pick (with small hunks) :
- https://github.com/falcosecurity/libs/pull/1349
- https://github.com/falcosecurity/libs/pull/1415