### PR TITLE
Fixes RHEL 9.3 sys_enter_args padding

### DIFF
--- a/driver/bpf/types.h
+++ b/driver/bpf/types.h
@@ -54,7 +54,7 @@ struct sys_exit_args {
     // lazy preemption adds some fields to the tracepoint context format.
     // This extra padding covers those new (unneeded) fields,
     // and ensures the remainder of the structure is at the correct offsets.
-	__u32 pad2;
+	__u64 pad2;
 #endif
 #if !defined(RHEL_RELEASE_CODE) || RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(8, 0)
 	int id;

--- a/driver/bpf/types.h
+++ b/driver/bpf/types.h
@@ -31,11 +31,10 @@ struct sys_enter_args {
 #else
 struct sys_enter_args {
 	__u64 pad;
-#if defined(RHEL_RELEASE_CODE) && RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 3)
-    // on RHEL 9.3 and newer, support has been added for lazy pre-emption, which
-    // adds some fields to the tracepoint context format. This extra padding
-    // covers those new (unneeded) fields, and ensures the remainder of the structure
-    // is at the correct offsets.
+#ifdef CONFIG_PREEMPT_LAZY
+    // lazy preemption adds some fields to the tracepoint context format.
+    // This extra padding covers those new (unneeded) fields,
+    // and ensures the remainder of the structure is at the correct offsets.
 	__u32 pad2;
 #endif
 	long id;
@@ -51,11 +50,10 @@ struct sys_exit_args {
 #else
 struct sys_exit_args {
 	__u64 pad;
-#if defined(RHEL_RELEASE_CODE) && RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 3)
-    // on RHEL 9.3 and newer, support has been added for lazy pre-emption, which
-    // adds some fields to the tracepoint context format. This extra padding
-    // covers those new (unneeded) fields, and ensures the remainder of the structure
-    // is at the correct offsets.
+#ifdef CONFIG_PREEMPT_LAZY
+    // lazy preemption adds some fields to the tracepoint context format.
+    // This extra padding covers those new (unneeded) fields,
+    // and ensures the remainder of the structure is at the correct offsets.
 	__u32 pad2;
 #endif
 #if !defined(RHEL_RELEASE_CODE) || RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(8, 0)

--- a/driver/bpf/types.h
+++ b/driver/bpf/types.h
@@ -51,6 +51,13 @@ struct sys_exit_args {
 #else
 struct sys_exit_args {
 	__u64 pad;
+#if defined(RHEL_RELEASE_CODE) && RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 3)
+    // on RHEL 9.3 and newer, support has been added for lazy pre-emption, which
+    // adds some fields to the tracepoint context format. This extra padding
+    // covers those new (unneeded) fields, and ensures the remainder of the structure
+    // is at the correct offsets.
+	__u32 pad2;
+#endif
 #if !defined(RHEL_RELEASE_CODE) || RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(8, 0)
 	int id;
 #else

--- a/driver/bpf/types.h
+++ b/driver/bpf/types.h
@@ -31,7 +31,7 @@ struct sys_enter_args {
 #else
 struct sys_enter_args {
 	__u64 pad;
-#ifdef CONFIG_PREEMPT_LAZY
+#ifdef CONFIG_HAVE_PREEMPT_LAZY
     // lazy preemption adds some fields to the tracepoint context format.
     // This extra padding covers those new (unneeded) fields,
     // and ensures the remainder of the structure is at the correct offsets.
@@ -50,7 +50,7 @@ struct sys_exit_args {
 #else
 struct sys_exit_args {
 	__u64 pad;
-#ifdef CONFIG_PREEMPT_LAZY
+#ifdef CONFIG_HAVE_PREEMPT_LAZY
     // lazy preemption adds some fields to the tracepoint context format.
     // This extra padding covers those new (unneeded) fields,
     // and ensures the remainder of the structure is at the correct offsets.

--- a/driver/bpf/types.h
+++ b/driver/bpf/types.h
@@ -31,6 +31,13 @@ struct sys_enter_args {
 #else
 struct sys_enter_args {
 	__u64 pad;
+#if defined(RHEL_RELEASE_CODE) && RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 3)
+    // on RHEL 9.3 and newer, support has been added for lazy pre-emption, which
+    // adds some fields to the tracepoint context format. This extra padding
+    // covers those new (unneeded) fields, and ensures the remainder of the structure
+    // is at the correct offsets.
+	__u32 pad2;
+#endif
 	long id;
 	unsigned long args[6];
 };


### PR DESCRIPTION
Adds extra padding to sys_enter_args in the eBPF driver to account for new fields in the structure. Associated with https://github.com/stackrox/collector/pull/1442 