### PR TITLE
Use PPM RHEL macros

### DIFF
--- a/driver/bpf/types.h
+++ b/driver/bpf/types.h
@@ -56,6 +56,8 @@ struct sys_exit_args {
     // and ensures the remainder of the structure is at the correct offsets.
 	__u64 pad2;
 #endif
+// PPM_* macros used here instead of the plain RHEL_* equivalents,
+// since they are defined for all platforms (see ../ppm_version.h)
 #if PPM_RHEL_RELEASE_CODE >= PPM_RHEL_RELEASE_VERSION(8, 0)
 	int id;
 #else

--- a/driver/bpf/types.h
+++ b/driver/bpf/types.h
@@ -56,7 +56,7 @@ struct sys_exit_args {
     // and ensures the remainder of the structure is at the correct offsets.
 	__u64 pad2;
 #endif
-#if !defined(RHEL_RELEASE_CODE) || RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(8, 0)
+#if PPM_RHEL_RELEASE_CODE >= PPM_RHEL_RELEASE_VERSION(8, 0)
 	int id;
 #else
 	long id;


### PR DESCRIPTION
Fixes RHEL_* macro use in types.h, to instead use the always-defined PPM_* equivalent.