### PR TITLE
Ensure host path is used for BPF attachment

### DIFF
--- a/userspace/libscap/engine/bpf/attached_prog.c
+++ b/userspace/libscap/engine/bpf/attached_prog.c
@@ -54,7 +54,7 @@ static int __attach_tp(struct bpf_attached_prog* prog, char* last_err)
 	int efd = 0;
 	int err = 0;
 	char buf[SCAP_MAX_PATH_SIZE];
-	snprintf(buf, sizeof(buf), "/sys/kernel/debug/tracing/events/%s/id", prog->name);
+	snprintf(buf, sizeof(buf), "%s/sys/kernel/debug/tracing/events/%s/id", scap_get_host_root(), prog->name);
 	efd = open(buf, O_RDONLY, 0);
 	if(efd < 0)
 	{


### PR DESCRIPTION
As per stackrox/collector#1498, ensures that host path is used for BPF attachment. 