### PR TITLE
Split user info

### DIFF
--- a/userspace/libsinsp/filterchecks.cpp
+++ b/userspace/libsinsp/filterchecks.cpp
@@ -6177,22 +6177,27 @@ uint8_t* sinsp_filter_check_user::extract(sinsp_evt *evt, OUT uint32_t* len, boo
 	switch(m_field_id)
 	{
 	case TYPE_UID:
-		RETURN_EXTRACT_VAR(tinfo->m_user.uid);
+		m_uid = tinfo->m_user.uid();
+		RETURN_EXTRACT_VAR(m_uid);
 	case TYPE_NAME:
-		RETURN_EXTRACT_CSTR(tinfo->m_user.name);
+		m_strval = tinfo->m_user.name();
+		RETURN_EXTRACT_STRING(m_strval);
 	case TYPE_HOMEDIR:
-		RETURN_EXTRACT_CSTR(tinfo->m_user.homedir);
+		m_strval = tinfo->m_user.homedir();
+		RETURN_EXTRACT_STRING(m_strval);
 	case TYPE_SHELL:
-		RETURN_EXTRACT_CSTR(tinfo->m_user.shell);
+		m_strval = tinfo->m_user.shell();
+		RETURN_EXTRACT_STRING(m_strval);
 	case TYPE_LOGINUID:
 		m_s64val = (int64_t)-1;
-		if(tinfo->m_loginuser.uid < UINT32_MAX)
+		if(tinfo->m_loginuser.uid() < UINT32_MAX)
 		{
-			m_s64val = (int64_t)tinfo->m_loginuser.uid;
+			m_s64val = (int64_t)tinfo->m_loginuser.uid();
 		}
 		RETURN_EXTRACT_VAR(m_s64val);
 	case TYPE_LOGINNAME:
-		RETURN_EXTRACT_CSTR(tinfo->m_loginuser.name);
+		m_strval = tinfo->m_loginuser.name();
+		RETURN_EXTRACT_STRING(m_strval);
 	default:
 		ASSERT(false);
 		break;
@@ -6237,9 +6242,11 @@ uint8_t* sinsp_filter_check_group::extract(sinsp_evt *evt, OUT uint32_t* len, bo
 	switch(m_field_id)
 	{
 	case TYPE_GID:
-		RETURN_EXTRACT_VAR(tinfo->m_group.gid);
+		m_gid = tinfo->m_group.gid();
+		RETURN_EXTRACT_VAR(m_gid);
 	case TYPE_NAME:
-		RETURN_EXTRACT_CSTR(tinfo->m_group.name);
+		m_name = tinfo->m_group.name();
+		RETURN_EXTRACT_STRING(m_name);
 	default:
 		ASSERT(false);
 		break;

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -1611,9 +1611,9 @@ void sinsp_parser::parse_clone_exit_caller(sinsp_evt *evt, int64_t child_tid)
 	/* Refresh user / loginuser / group */
 	if(child_tinfo->m_container_id.empty() == false)
 	{
-		child_tinfo->set_user(child_tinfo->m_user.uid);
-		child_tinfo->set_loginuser(child_tinfo->m_loginuser.uid);
-		child_tinfo->set_group(child_tinfo->m_group.gid);
+		child_tinfo->set_user(child_tinfo->m_user.uid());
+		child_tinfo->set_loginuser(child_tinfo->m_loginuser.uid());
+		child_tinfo->set_group(child_tinfo->m_group.gid());
 	}
 
 	/* If there's a listener, invoke it */
@@ -2159,9 +2159,9 @@ void sinsp_parser::parse_clone_exit_child(sinsp_evt *evt)
 	/* Refresh user / loginuser / group */
 	if(child_tinfo->m_container_id.empty() == false)
 	{
-		child_tinfo->set_user(child_tinfo->m_user.uid);
-		child_tinfo->set_loginuser(child_tinfo->m_loginuser.uid);
-		child_tinfo->set_group(child_tinfo->m_group.gid);
+		child_tinfo->set_user(child_tinfo->m_user.uid());
+		child_tinfo->set_loginuser(child_tinfo->m_loginuser.uid());
+		child_tinfo->set_group(child_tinfo->m_group.gid());
 	}
 
 	//
@@ -2705,7 +2705,7 @@ void sinsp_parser::parse_execve_exit(sinsp_evt *evt)
 	if(evt->get_num_params() > 26)
 	{
 		parinfo = evt->get_param(26);
-		evt->m_tinfo->m_user.uid = *(uint32_t *)parinfo->m_val;
+		evt->m_tinfo->m_user.set_uid(*(uint32_t *)parinfo->m_val);
 	}
 
 	//
@@ -2747,9 +2747,9 @@ void sinsp_parser::parse_execve_exit(sinsp_evt *evt)
 	//
 	if(container_id != evt->m_tinfo->m_container_id)
 	{
-		evt->m_tinfo->set_user(evt->m_tinfo->m_user.uid);
-		evt->m_tinfo->set_loginuser(evt->m_tinfo->m_loginuser.uid);
-		evt->m_tinfo->set_group(evt->m_tinfo->m_group.gid);
+		evt->m_tinfo->set_user(evt->m_tinfo->m_user.uid());
+		evt->m_tinfo->set_loginuser(evt->m_tinfo->m_loginuser.uid());
+		evt->m_tinfo->set_group(evt->m_tinfo->m_group.gid());
 	}
 
 	//
@@ -6388,9 +6388,9 @@ void sinsp_parser::parse_chroot_exit(sinsp_evt *evt)
 		//
 		if(container_id != evt->m_tinfo->m_container_id)
 		{
-			evt->m_tinfo->set_user(evt->m_tinfo->m_user.uid);
-			evt->m_tinfo->set_loginuser(evt->m_tinfo->m_loginuser.uid);
-			evt->m_tinfo->set_group(evt->m_tinfo->m_group.gid);
+			evt->m_tinfo->set_user(evt->m_tinfo->m_user.uid());
+			evt->m_tinfo->set_loginuser(evt->m_tinfo->m_loginuser.uid());
+			evt->m_tinfo->set_group(evt->m_tinfo->m_group.gid());
 		}
 	}
 }

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -449,9 +449,10 @@ void sinsp::init()
 	m_inited = true;
 }
 
-void sinsp::set_import_users(bool import_users)
+void sinsp::set_import_users(bool import_users, bool user_details)
 {
 	m_usergroup_manager.m_import_users = import_users;
+	m_usergroup_manager.m_user_details_enabled = user_details;
 }
 
 /*=============================== OPEN METHODS ===============================*/

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -317,12 +317,18 @@ public:
 	  creating them can increase the startup time. Moreover, they contain
 	  information that could be privacy sensitive.
 
-	  \note default behavior is import_users=true.
+	  \param user_details if set to false, no extended user information will be
+	  stored in sinsp_threadinfo, only user id/group id will be available. By
+	  default thread information is enriched with the full set of user
+	  information, i.e. name, homedir, shell, group name. The parameter
+	  controls this behavior, an can be used to reduce memory footprint.
+
+	  \note default behavior is import_users=true, user_details=true
 
 	  @throws a sinsp_exception containing the error string is thrown in case
 	   of failure.
 	*/
-	void set_import_users(bool import_users);
+	void set_import_users(bool import_users, bool user_details = true);
 
 	/*!
 	  \brief temporarily pauses event capture.
@@ -788,6 +794,14 @@ public:
 	inline bool is_debug_enabled()
 	{
 		return m_isdebug_enabled;
+	}
+
+	/*!
+	  \brief Returns true if extended user information is collected.
+	*/
+	inline bool is_user_details_enabled()
+	{
+		return m_usergroup_manager.m_user_details_enabled;
 	}
 
 	/*!

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -154,10 +154,6 @@ void sinsp_threadinfo::init()
 	m_exe_ino_mtime = 0;
 	m_exe_ino_ctime_duration_clone_ts = 0;
 	m_exe_ino_ctime_duration_pidns_start = 0;
-
-	memset(&m_user, 0, sizeof(scap_userinfo));
-	memset(&m_group, 0, sizeof(scap_groupinfo));
-	memset(&m_loginuser, 0, sizeof(scap_userinfo));
 }
 
 sinsp_threadinfo::~sinsp_threadinfo()
@@ -574,19 +570,27 @@ void sinsp_threadinfo::set_user(uint32_t uid)
 	if (!user)
 	{
 		auto notify = m_inspector->is_live() || m_inspector->is_syscall_plugin();
-		user = m_inspector->m_usergroup_manager.add_user(m_container_id, m_pid, uid, m_group.gid, NULL, NULL, NULL, notify);
+		user = m_inspector->m_usergroup_manager.add_user(m_container_id, m_pid, uid, m_group.gid(), NULL, NULL, NULL, notify);
 	}
+
 	if (user)
 	{
-		memcpy(&m_user, user, sizeof(scap_userinfo));
+		m_user.set_uid(user->uid);
+		m_user.set_gid(m_group.gid());
+
+		if (m_inspector->is_user_details_enabled())
+		{
+			m_user.set_name(user->name, sizeof(user->name));
+			m_user.set_homedir(user->homedir, sizeof(user->homedir));
+			m_user.set_shell(user->shell, sizeof(user->shell));
+		}
 	}
 	else
 	{
-		m_user.uid = uid;
-		m_user.gid = m_group.gid;
-		strlcpy(m_user.name, (uid == 0) ? "root" : "<NA>", sizeof(m_user.name));
-		strlcpy(m_user.homedir, (uid == 0) ? "/root" : "<NA>", sizeof(m_user.homedir));
-		strlcpy(m_user.shell, "<NA>", sizeof(m_user.shell));
+		// No need to set name/homedir/shell, the default values from
+		// sinsp_userinfo are going to be used.
+		m_user.set_uid(uid);
+		m_user.set_gid(m_group.gid());
 	}
 }
 
@@ -600,30 +604,44 @@ void sinsp_threadinfo::set_group(uint32_t gid)
 	}
 	if (group)
 	{
-		memcpy(&m_group, group, sizeof(scap_groupinfo));
+		m_group.set_gid(group->gid);
+
+		if (m_inspector->is_user_details_enabled())
+		{
+			m_group.set_name(group->name, sizeof(group->name));
+		}
 	}
 	else
 	{
-		m_group.gid = gid;
-		strlcpy(m_group.name, (gid == 0) ? "root" : "<NA>", sizeof(m_group.name));
+		// No need to set name/homedir/shell, the default values from
+		// sinsp_userinfo are going to be used.
+		m_group.set_gid(gid);
 	}
-	m_user.gid = m_group.gid;
+	m_user.set_gid(m_group.gid());
 }
 
 void sinsp_threadinfo::set_loginuser(uint32_t loginuid)
 {
 	scap_userinfo *login_user = m_inspector->m_usergroup_manager.get_user(m_container_id, loginuid);
+
 	if (login_user)
 	{
-		memcpy(&m_loginuser, login_user, sizeof(scap_userinfo));
+		m_loginuser.set_uid(login_user->uid);
+		m_loginuser.set_gid(m_group.gid());
+
+		if (m_inspector->is_user_details_enabled())
+		{
+			m_loginuser.set_name(login_user->name, sizeof(login_user->name));
+			m_loginuser.set_homedir(login_user->homedir, sizeof(login_user->homedir));
+			m_loginuser.set_shell(login_user->shell, sizeof(login_user->shell));
+		}
 	}
 	else
 	{
-		m_loginuser.uid = loginuid;
-		m_loginuser.gid = m_group.gid;
-		strlcpy(m_loginuser.name, loginuid == 0 ? "root" : "<NA>", sizeof(m_loginuser.name));
-		strlcpy(m_loginuser.homedir, loginuid == 0  ? "/root" : "<NA>", sizeof(m_loginuser.homedir));
-		strlcpy(m_loginuser.shell, "<NA>", sizeof(m_loginuser.shell));
+		// No need to set name/homedir/shell, the default values from
+		// sinsp_userinfo are going to be used.
+		m_loginuser.set_uid(loginuid);
+		m_loginuser.set_gid(m_group.gid());
 	}
 }
 
@@ -1945,8 +1963,8 @@ void sinsp_thread_manager::thread_to_scap(sinsp_threadinfo& tinfo, 	scap_threadi
 
 	sctinfo->flags = tinfo.m_flags ;
 	sctinfo->fdlimit = tinfo.m_fdlimit;
-	sctinfo->uid = tinfo.m_user.uid;
-	sctinfo->gid = tinfo.m_group.gid;
+	sctinfo->uid = tinfo.m_user.uid();
+	sctinfo->gid = tinfo.m_group.gid();
 	sctinfo->vmsize_kb = tinfo.m_vmsize_kb;
 	sctinfo->vmrss_kb = tinfo.m_vmrss_kb;
 	sctinfo->vmswap_kb = tinfo.m_vmswap_kb;
@@ -1955,7 +1973,7 @@ void sinsp_thread_manager::thread_to_scap(sinsp_threadinfo& tinfo, 	scap_threadi
 	sctinfo->vtid = tinfo.m_vtid;
 	sctinfo->vpid = tinfo.m_vpid;
 	sctinfo->fdlist = NULL;
-	sctinfo->loginuid = tinfo.m_loginuser.uid;
+	sctinfo->loginuid = tinfo.m_loginuser.uid();
 	sctinfo->filtered_out = false;
 }
 
@@ -2181,9 +2199,9 @@ threadinfo_map_t::ptr_t sinsp_thread_manager::get_thread_ref(int64_t tid, bool q
             newti->m_not_expired_children = 0;
             newti->m_comm = "<NA>";
             newti->m_exe = "<NA>";
-            newti->m_user.uid = 0xffffffff;
-            newti->m_group.gid = 0xffffffff;
-            newti->m_loginuser.uid = 0xffffffff;
+            newti->m_user.set_uid(0xffffffff);
+            newti->m_group.set_gid(0xffffffff);
+            newti->m_loginuser.set_uid(0xffffffff);
         }
 
         //

--- a/userspace/libsinsp/threadinfo.h
+++ b/userspace/libsinsp/threadinfo.h
@@ -72,6 +72,78 @@ class SINSP_PUBLIC sinsp_threadinfo: public libsinsp::state::table_entry
 {
 
 public:
+	class sinsp_userinfo
+	{
+	public:
+		sinsp_userinfo() {
+			m_uid = 0xffffffff;
+			m_gid = 0xffffffff;
+		}
+		uint32_t uid() const { return m_uid; }
+		uint32_t gid() const { return m_gid; }
+		std::string name() const {
+			if (m_name.empty())
+			{
+				return (m_uid == 0) ? "root" : "<NA>";
+			}
+			else
+			{
+				return m_name;
+			}
+		};
+		std::string homedir() const {
+			if (m_homedir.empty())
+			{
+				return (m_uid == 0) ? "/root" : "<NA>";
+			}
+			else
+			{
+				return m_homedir;
+			}
+		};
+		std::string shell() const { return m_shell.empty() ? "<NA>" : m_shell; };
+
+		void set_uid(uint32_t uid) { m_uid = uid; };
+		void set_gid(uint32_t gid) { m_gid = gid; };
+		void set_name(char *name, size_t length) { m_name.assign(name, length); };
+		void set_homedir(char *homedir, size_t length) { m_homedir.assign(homedir, length); };
+		void set_shell(char *shell, size_t length) { m_shell.assign(shell, length); };
+
+	private:
+		uint32_t m_uid; ///< User ID
+		uint32_t m_gid; ///< Group ID
+		std::string m_name; ///< Username
+		std::string m_homedir; ///< Home directory
+		std::string m_shell; ///< Shell program
+	};
+
+
+	class sinsp_groupinfo
+	{
+	public:
+		sinsp_groupinfo() {
+			m_gid = 0xffffffff;
+		}
+		uint32_t gid() const { return m_gid; };
+		std::string name() const {
+			if (m_name.empty())
+			{
+				return (m_gid == 0) ? "root" : "<NA>";
+			}
+			else
+			{
+				return m_name;
+			}
+		};
+
+		void set_gid(uint32_t gid) { m_gid = gid; };
+		void set_name(char *name, size_t length) { m_name.assign(name, length); };
+	private:
+		uint32_t m_gid; ///< Group ID
+		std::string m_name; ///< Group name
+	};
+
+
 	sinsp_threadinfo(
 		sinsp *inspector = nullptr,
 		std::shared_ptr<libsinsp::state::dynamic_struct::field_infos> dyn_fields = nullptr);
@@ -419,9 +491,9 @@ public:
 	std::string m_container_id; ///< heuristic-based container id
 	uint32_t m_flags; ///< The thread flags. See the PPM_CL_* declarations in ppm_events_public.h.
 	int64_t m_fdlimit;  ///< The maximum number of FDs this thread can open
-	scap_userinfo m_user; ///< user infos
-	scap_userinfo m_loginuser; ///< loginuser infos (auid)
-	scap_groupinfo m_group; ///< group infos
+	sinsp_userinfo m_user; ///< user infos
+	sinsp_userinfo m_loginuser; ///< loginuser infos (auid)
+	sinsp_groupinfo m_group; ///< group infos
 	uint64_t m_cap_permitted; ///< permitted capabilities
 	uint64_t m_cap_effective; ///< effective capabilities
 	uint64_t m_cap_inheritable; ///< inheritable capabilities

--- a/userspace/libsinsp/user.cpp
+++ b/userspace/libsinsp/user.cpp
@@ -118,6 +118,7 @@ using namespace std;
 // clang-format off
 sinsp_usergroup_manager::sinsp_usergroup_manager(sinsp* inspector)
 	: m_import_users(true)
+	, m_user_details_enabled(true)
 	, m_last_flush_time_ns(0)
 	, m_inspector(inspector)
 	, m_host_root(m_inspector->get_host_root())

--- a/userspace/libsinsp/user.h
+++ b/userspace/libsinsp/user.h
@@ -133,6 +133,8 @@ public:
 	//
 	bool m_import_users;
 
+	bool m_user_details_enabled;
+
 private:
 	scap_userinfo *add_host_user(uint32_t uid, uint32_t gid, const char *name, const char *home, const char *shell, bool notify);
 	scap_userinfo *add_container_user(const std::string &container_id, int64_t pid, uint32_t uid, bool notify);


### PR DESCRIPTION
In order to make memory management more flexible, split user info stored in `sinsp_threadinfo` into essential and extended parts. This can have significant impact in case of process-heavy workloads, as in the example below:

![mem](https://github.com/stackrox/falcosecurity-libs/assets/634032/5a0fffa1-9932-4632-a818-0bd1b0e6455a)

The memory usage breakdown shows that most of it goes to manage
`sinsp_threadinfo` (where `_M_allocate_node` is a part of threadinfo allocation
process, e.g. in `get_thread_ref`):

```
73.4  43.0%  43.0%     73.5  43.1% std::__detail::_Hashtable_alloc::_M_allocate_node
37.2  21.8%  64.8%     37.2  21.8% sinsp_parser::reserve_event_buffer
30.7  18.0%  82.8%    109.9  64.4% sinsp_thread_manager::new_threadinfo
```