### PR TITLE
fix(bpf): fix rss_stat being an array and not a struct

### DIFF
--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -858,7 +858,7 @@ static __always_inline unsigned long bpf_get_mm_counter(struct mm_struct *mm,
 	long val;
 
 	// See 6.2 kernel commit: https://github.com/torvalds/linux/commit/f1a7941243c102a44e8847e3b94ff4ff3ec56f25
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 2, 0)
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(6, 2, 0)) || (PPM_RHEL_RELEASE_CODE > 0 && PPM_RHEL_RELEASE_CODE < PPM_RHEL_RELEASE_VERSION(9, 4))
 	bpf_probe_read_kernel(&val, sizeof(val), &mm->rss_stat.count[member]);
 #else
 	bpf_probe_read_kernel(&val, sizeof(val), &mm->rss_stat[member].count);

--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -858,10 +858,10 @@ static __always_inline unsigned long bpf_get_mm_counter(struct mm_struct *mm,
 	long val;
 
 	// See 6.2 kernel commit: https://github.com/torvalds/linux/commit/f1a7941243c102a44e8847e3b94ff4ff3ec56f25
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(6, 2, 0)) || (PPM_RHEL_RELEASE_CODE > 0 && PPM_RHEL_RELEASE_CODE < PPM_RHEL_RELEASE_VERSION(9, 4))
-	bpf_probe_read_kernel(&val, sizeof(val), &mm->rss_stat.count[member]);
-#else
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 2, 0) || (PPM_RHEL_RELEASE_CODE > 0 && PPM_RHEL_RELEASE_CODE >= PPM_RHEL_RELEASE_VERSION(9, 4))
 	bpf_probe_read_kernel(&val, sizeof(val), &mm->rss_stat[member].count);
+#else
+	bpf_probe_read_kernel(&val, sizeof(val), &mm->rss_stat.count[member]);
 #endif
 	if (val < 0)
 		val = 0;

--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -857,11 +857,10 @@ static __always_inline unsigned long bpf_get_mm_counter(struct mm_struct *mm,
 {
 	long val;
 
-	// See 6.2 kernel commit: https://github.com/torvalds/linux/commit/f1a7941243c102a44e8847e3b94ff4ff3ec56f25
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 2, 0)
-	bpf_probe_read_kernel(&val, sizeof(val), &mm->rss_stat.count[member]);
-#else
+#ifdef HAS_RSS_STAT_ARRAY
 	bpf_probe_read_kernel(&val, sizeof(val), &mm->rss_stat[member].count);
+#else
+	bpf_probe_read_kernel(&val, sizeof(val), &mm->rss_stat.count[member]);
 #endif
 	if (val < 0)
 		val = 0;

--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -857,10 +857,11 @@ static __always_inline unsigned long bpf_get_mm_counter(struct mm_struct *mm,
 {
 	long val;
 
-#ifdef HAS_RSS_STAT_ARRAY
-	bpf_probe_read_kernel(&val, sizeof(val), &mm->rss_stat[member].count);
-#else
+	// See 6.2 kernel commit: https://github.com/torvalds/linux/commit/f1a7941243c102a44e8847e3b94ff4ff3ec56f25
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 2, 0)
 	bpf_probe_read_kernel(&val, sizeof(val), &mm->rss_stat.count[member]);
+#else
+	bpf_probe_read_kernel(&val, sizeof(val), &mm->rss_stat[member].count);
 #endif
 	if (val < 0)
 		val = 0;


### PR DESCRIPTION
This error was originally [fixed upstream by adding a full check at source configuration time](https://github.com/falcosecurity/libs/pull/1729), this is incompatible with our way of building drivers, so we are skipping that and directly making the check we need explicit. It would be a big deal, but with eBPF deprecation and full removal in the horizon, I think this is an acceptable tradeoff.

