### PR TITLE
Expose extract_single in filterchecks

### DIFF
--- a/userspace/libsinsp/sinsp_filtercheck.h
+++ b/userspace/libsinsp/sinsp_filtercheck.h
@@ -302,7 +302,8 @@ public:
 			       uint32_t len);
 
 
-	virtual uint8_t* extract(sinsp_evt*, OUT uint32_t* len, bool sanitize_strings = true);
+	// \param len [out] length in bytes for the returned value
+	virtual uint8_t* extract_single(sinsp_evt*, uint32_t* len, bool sanitize_strings = true);
 
 protected:
 	virtual bool compare_nocache(sinsp_evt*);
@@ -326,8 +327,6 @@ protected:
 	//
 	// \param values [out] the values extracted from the filter check
 	bool extract_nocache(sinsp_evt *evt, std::vector<extract_value_t>& values, bool sanitize_strings = true);
-	// \param len [out] length in bytes for the returned value
-	virtual uint8_t* extract_single(sinsp_evt*, uint32_t* len, bool sanitize_strings = true);
 
 	bool compare_rhs(cmpop op, ppm_param_type type, const void* operand1, uint32_t op1_len = 0);
 	bool compare_rhs(cmpop op, ppm_param_type type, std::vector<extract_value_t>& values);


### PR DESCRIPTION
We had this exposed before in order to allow EventExtractor to work, but it was renamed upstream.

