### PR TITLE
Fix COS verifier issue

### DIFF
--- a/driver/modern_bpf/helpers/extract/extract_from_kernel.h
+++ b/driver/modern_bpf/helpers/extract/extract_from_kernel.h
@@ -422,19 +422,25 @@ static __always_inline uint64_t extract__capability(struct task_struct *task, en
 {
 	kernel_cap_t cap_struct;
 	unsigned long capability;
+	struct cred *task_cred;
+
+	READ_TASK_FIELD_INTO(&task_cred, task, cred);
+
+	if (task_cred == NULL)
+		return 0;
 
 	switch(capability_type)
 	{
 	case CAP_INHERITABLE:
-		READ_TASK_FIELD_INTO(&cap_struct, task, cred, cap_inheritable);
+		BPF_CORE_READ_INTO(&cap_struct, task_cred, cap_inheritable);
 		break;
 
 	case CAP_PERMITTED:
-		READ_TASK_FIELD_INTO(&cap_struct, task, cred, cap_permitted);
+		BPF_CORE_READ_INTO(&cap_struct, task_cred, cap_permitted);
 		break;
 
 	case CAP_EFFECTIVE:
-		READ_TASK_FIELD_INTO(&cap_struct, task, cred, cap_effective);
+		BPF_CORE_READ_INTO(&cap_struct, task_cred, cap_effective);
 		break;
 
 	default:
@@ -813,8 +819,15 @@ static __always_inline unsigned long extract__clone_flags(struct task_struct *ta
  */
 static __always_inline void extract__euid(struct task_struct *task, uint32_t *euid)
 {
+	struct cred *task_cred;
+
+	READ_TASK_FIELD_INTO(&task_cred, task, cred);
+
+	if (task_cred == NULL)
+		return;
+
 	*euid = UINT32_MAX;
-	READ_TASK_FIELD_INTO(euid, task, cred, euid.val);
+	BPF_CORE_READ_INTO(euid, task_cred, euid.val);
 }
 
 /**
@@ -825,7 +838,14 @@ static __always_inline void extract__euid(struct task_struct *task, uint32_t *eu
  */
 static __always_inline void extract__egid(struct task_struct *task, uint32_t *egid)
 {
-	READ_TASK_FIELD_INTO(egid, task, cred, egid.val);
+	struct cred *task_cred;
+
+	READ_TASK_FIELD_INTO(&task_cred, task, cred);
+
+	if (task_cred == NULL)
+		return;
+
+	BPF_CORE_READ_INTO(egid, task_cred, egid.val);
 }
 
 /////////////////////////
@@ -988,7 +1008,14 @@ static __always_inline uint32_t bpf_map_id_up(struct uid_gid_map *map, uint32_t 
 static __always_inline bool groups_search(struct task_struct *task, uint32_t grp)
 {
 	struct group_info *group_info = NULL;
-	READ_TASK_FIELD_INTO(&group_info, task, cred, group_info);
+	struct cred *task_cred;
+
+	READ_TASK_FIELD_INTO(&task_cred, task, cred);
+
+	if (task_cred == NULL)
+		return false;
+
+	BPF_CORE_READ_INTO(&group_info, task_cred, group_info);
 	if(!group_info)
 	{
 		return false;
@@ -1048,8 +1075,14 @@ static __always_inline bool extract__exe_writable(struct task_struct *task, stru
 
 	uint32_t fsuid;
 	uint32_t fsgid;
-	READ_TASK_FIELD_INTO(&fsuid, task, cred, fsuid.val);
-	READ_TASK_FIELD_INTO(&fsgid, task, cred, fsgid.val);
+	struct cred *task_cred;
+
+	READ_TASK_FIELD_INTO(&task_cred, task, cred);
+
+	if (task_cred != NULL) {
+		READ_TASK_FIELD_INTO(&fsuid, task_cred, fsuid.val);
+		READ_TASK_FIELD_INTO(&fsgid, task_cred, fsgid.val);
+	}
 
 	/* HAS_UNMAPPED_ID() */
 	if(i_uid == -1 || i_gid == -1)
@@ -1102,7 +1135,11 @@ static __always_inline bool extract__exe_writable(struct task_struct *task, stru
 	}
 
 	struct user_namespace *ns;
-	READ_TASK_FIELD_INTO(&ns, task, cred, user_ns);
+
+	if (task_cred == NULL)
+		return false;
+
+	BPF_CORE_READ_INTO(&ns, task_cred, user_ns);
 	if(ns == NULL)
 	{
 		return false;
@@ -1111,7 +1148,7 @@ static __always_inline bool extract__exe_writable(struct task_struct *task, stru
 	bool kgid_mapped = bpf_map_id_up(&ns->gid_map, i_gid) != (uint32_t)-1;
 
 	kernel_cap_t cap_struct = {0};
-	READ_TASK_FIELD_INTO(&cap_struct, task, cred, cap_effective);
+	BPF_CORE_READ_INTO(&cap_struct, task_cred, cap_effective);
 	// Kernel 6.3 changed the kernel_cap_struct type from uint32_t[2] to uint64_t.
 	// Luckily enough, it also changed field name from cap to val.
 	if(bpf_core_field_exists(((struct kernel_cap_struct *)0)->cap))

--- a/driver/modern_bpf/helpers/extract/extract_from_kernel.h
+++ b/driver/modern_bpf/helpers/extract/extract_from_kernel.h
@@ -422,7 +422,7 @@ static __always_inline uint64_t extract__capability(struct task_struct *task, en
 {
 	kernel_cap_t cap_struct;
 	unsigned long capability;
-	struct cred *task_cred;
+	const struct cred *task_cred;
 
 	READ_TASK_FIELD_INTO(&task_cred, task, cred);
 
@@ -819,14 +819,14 @@ static __always_inline unsigned long extract__clone_flags(struct task_struct *ta
  */
 static __always_inline void extract__euid(struct task_struct *task, uint32_t *euid)
 {
-	struct cred *task_cred;
+	const struct cred *task_cred;
+	*euid = UINT32_MAX;
 
 	READ_TASK_FIELD_INTO(&task_cred, task, cred);
 
 	if (task_cred == NULL)
 		return;
 
-	*euid = UINT32_MAX;
 	BPF_CORE_READ_INTO(euid, task_cred, euid.val);
 }
 
@@ -838,7 +838,7 @@ static __always_inline void extract__euid(struct task_struct *task, uint32_t *eu
  */
 static __always_inline void extract__egid(struct task_struct *task, uint32_t *egid)
 {
-	struct cred *task_cred;
+	const struct cred *task_cred;
 
 	READ_TASK_FIELD_INTO(&task_cred, task, cred);
 
@@ -1008,7 +1008,7 @@ static __always_inline uint32_t bpf_map_id_up(struct uid_gid_map *map, uint32_t 
 static __always_inline bool groups_search(struct task_struct *task, uint32_t grp)
 {
 	struct group_info *group_info = NULL;
-	struct cred *task_cred;
+	const struct cred *task_cred;
 
 	READ_TASK_FIELD_INTO(&task_cred, task, cred);
 
@@ -1075,7 +1075,7 @@ static __always_inline bool extract__exe_writable(struct task_struct *task, stru
 
 	uint32_t fsuid;
 	uint32_t fsgid;
-	struct cred *task_cred;
+	const struct cred *task_cred;
 
 	READ_TASK_FIELD_INTO(&task_cred, task, cred);
 


### PR DESCRIPTION
There is an unexpected difference betweek kernels compiled with gcc and clang. The former one doesn't support rcu attributes yet, meaning that READ_TASK_FIELD_INFO on task->cred produces PTR_TO_BTF_ID. The latter one does support rcu attribute, and READ_TASK_FIELD_INFO ends up with PTR_TO_BTF_ID | MEM_RCU | MAYBE_NULL [[1]]. COS seems to be using clang to compile the kernel:

    # from /boot/config
    CONFIG_CC_VERSION_TEXT="Chromium OS 16.0_pre484197_p20230405-r12 clang version 16.0.0
    (/var/tmp/portage/sys-devel/llvm-16.0_pre484197_p20230405-r12/work/llvm-16.0_pre484197_p20230405/clang 2916b99182752b1aece8cc4479d8d6a20b5e02da)"

The verifier doesn't like the
null part, and to fix it we need to break a chain of reading and verify that the cred structure is not null.

[1]: https://lore.kernel.org/bpf/20230228040121.94253-3-alexei.starovoitov@gmail.com/