### PR TITLE
Only load interesting syscalls

### DIFF
--- a/userspace/libpman/include/libpman.h
+++ b/userspace/libpman/include/libpman.h
@@ -18,6 +18,7 @@ limitations under the License.
 
 #pragma once
 
+#include "ppm_events_public.h"
 #include <stdbool.h>
 #include <stdint.h>
 
@@ -242,12 +243,17 @@ extern "C"
 	int pman_detach_signal_deliver(void);
 
 	/**
-	 * @brief Mark programs for uninteresting syscalls to no autoload
+	 * @brief Mark programs for uninteresting syscalls to not autoload
+	 *
+	 * The provided list of syscalls is an array of booleans, where true
+	 * means the syscall is interesting and should be loaded into the
+	 * kernel, otherwise it will be skipped. The index for each element
+	 * corresponds to a syscall as defined in `driver/ppm_events_public.h`
 	 *
 	 * @param ppm_sc_of_interest list of interesting ppm_sc.
 	 * @returns `0` on success, `errno` in case of error.
 	 */
-	int pman_set_autoload_programs(const bool ppm_sc_of_interest[]);
+	int pman_set_autoload_programs(const bool ppm_sc_of_interest[PPM_SC_MAX]);
 
 	/////////////////////////////
 	// MANAGE RINGBUFFERS
@@ -432,9 +438,16 @@ extern "C"
 	 * Returns the fd of the right bpf program to call.
 	 *
 	 * @param ppm_sc_of_interest List of interesting syscalls.
+	 *
+	 * The provided list of syscalls is an array of booleans, where true
+	 * means the syscall has been loaded into the kernel and a file
+	 * descriptor for it should be added to the tail call map, otherwise
+	 * it will be skipped. The index for each element corresponds to a
+	 * syscall as defined in `driver/ppm_events_public.h`
+	 *
 	 * @return `0` on success, `errno` in case of error.
 	 */
-	int pman_fill_syscalls_tail_table(bool ppm_sc_of_interest[]);
+	int pman_fill_syscalls_tail_table(const bool ppm_sc_of_interest[PPM_SC_MAX]);
 
 	/**
 	 * @brief Performs all necessary operations on maps before the
@@ -452,10 +465,16 @@ extern "C"
 	 * - Set values to BPF global variables.
 	 * - Fill tail tables.
 	 *
+	 * The provided list of syscalls is an array of booleans, where true
+	 * means the syscall has been loaded into the kernel and a file
+	 * descriptor for it should be added to the tail call map, otherwise
+	 * it will be skipped. The index for each element corresponds to a
+	 * syscall as defined in `driver/ppm_events_public.h`
+	 *
 	 * @param ppm_sc_of_interest List of interesting syscalls.
 	 * @return `0` on success, `errno` in case of error.
 	 */
-	int pman_finalize_maps_after_loading(bool ppm_sc_of_interest[]);
+	int pman_finalize_maps_after_loading(const bool ppm_sc_of_interest[PPM_SC_MAX]);
 
 	/**
 	 * @brief Mark a single syscall as (un)interesting

--- a/userspace/libpman/include/libpman.h
+++ b/userspace/libpman/include/libpman.h
@@ -241,6 +241,14 @@ extern "C"
 	 */
 	int pman_detach_signal_deliver(void);
 
+	/**
+	 * @brief Mark programs for uninteresting syscalls to no autoload
+	 *
+	 * @param ppm_sc_of_interest list of interesting ppm_sc.
+	 * @returns `0` on success, `errno` in case of error.
+	 */
+	int pman_set_autoload_programs(const bool ppm_sc_of_interest[]);
+
 	/////////////////////////////
 	// MANAGE RINGBUFFERS
 	/////////////////////////////
@@ -423,9 +431,10 @@ extern "C"
 	 * syscall_exit_tail_table(syscall_id, exit_program_fd).
 	 * Returns the fd of the right bpf program to call.
 	 *
+	 * @param ppm_sc_of_interest List of interesting syscalls.
 	 * @return `0` on success, `errno` in case of error.
 	 */
-	int pman_fill_syscalls_tail_table(void);
+	int pman_fill_syscalls_tail_table(bool ppm_sc_of_interest[]);
 
 	/**
 	 * @brief Performs all necessary operations on maps before the
@@ -443,9 +452,10 @@ extern "C"
 	 * - Set values to BPF global variables.
 	 * - Fill tail tables.
 	 *
+	 * @param ppm_sc_of_interest List of interesting syscalls.
 	 * @return `0` on success, `errno` in case of error.
 	 */
-	int pman_finalize_maps_after_loading(void);
+	int pman_finalize_maps_after_loading(bool ppm_sc_of_interest[]);
 
 	/**
 	 * @brief Mark a single syscall as (un)interesting

--- a/userspace/libpman/src/maps.c
+++ b/userspace/libpman/src/maps.c
@@ -208,7 +208,7 @@ clean_add_program_to_tail_table:
 	return errno;
 }
 
-int pman_fill_syscalls_tail_table(bool ppm_sc_of_interest[])
+int pman_fill_syscalls_tail_table(const bool ppm_sc_of_interest[PPM_SC_MAX])
 {
 	int syscall_enter_tail_table_fd = 0;
 	int syscall_exit_tail_table_fd = 0;
@@ -364,7 +364,7 @@ int pman_prepare_maps_before_loading()
 	return err;
 }
 
-int pman_finalize_maps_after_loading(bool ppm_sc_of_interest[])
+int pman_finalize_maps_after_loading(const bool ppm_sc_of_interest[PPM_SC_MAX])
 {
 	int err;
 

--- a/userspace/libpman/src/maps.c
+++ b/userspace/libpman/src/maps.c
@@ -208,7 +208,7 @@ clean_add_program_to_tail_table:
 	return errno;
 }
 
-int pman_fill_syscalls_tail_table()
+int pman_fill_syscalls_tail_table(bool ppm_sc_of_interest[])
 {
 	int syscall_enter_tail_table_fd = 0;
 	int syscall_exit_tail_table_fd = 0;
@@ -233,6 +233,9 @@ int pman_fill_syscalls_tail_table()
 
 	for(int syscall_id = 0; syscall_id < SYSCALL_TABLE_SIZE; syscall_id++)
 	{
+		if (!ppm_sc_of_interest[g_syscall_table[syscall_id].ppm_sc]) {
+			continue;
+		}
 
 		/* Get event type from `g_syscall_table` */
 		enter_event_type = g_syscall_table[syscall_id].enter_event_type;
@@ -361,7 +364,7 @@ int pman_prepare_maps_before_loading()
 	return err;
 }
 
-int pman_finalize_maps_after_loading()
+int pman_finalize_maps_after_loading(bool ppm_sc_of_interest[])
 {
 	int err;
 
@@ -378,7 +381,7 @@ int pman_finalize_maps_after_loading()
 	pman_fill_syscall_sampling_table();
 	pman_fill_syscall_tracepoint_table();
 	pman_fill_ia32_to_64_table();
-	err = pman_fill_syscalls_tail_table();
+	err = pman_fill_syscalls_tail_table(ppm_sc_of_interest);
 	err = err ?: pman_fill_extra_event_prog_tail_table();
 	return err;
 }

--- a/userspace/libpman/src/programs.c
+++ b/userspace/libpman/src/programs.c
@@ -19,6 +19,7 @@ limitations under the License.
 #include "state.h"
 #include <driver/feature_gates.h>
 #include <libpman.h>
+#include <scap.h>
 
 /* Some notes about how a bpf program must be detached without unloading it:
  * https://lore.kernel.org/bpf/CAEf4BzZ8=dV0wvggAKnD64yXnhcXhdf1ovCT_LBd17RtJJXrdA@mail.gmail.com/T/
@@ -295,6 +296,33 @@ int pman_detach_signal_deliver()
 		return errno;
 	}
 	g_state.skel->links.signal_deliver = NULL;
+	return 0;
+}
+
+int pman_set_autoload_programs(const bool ppm_sc_of_interest[])
+{
+	char buff[4096];
+
+	for (unsigned int i = 0; i < PPM_SC_MAX; i++) {
+		const char* name = scap_get_ppm_sc_name(i);
+		unsigned int name_len = strlen(name) < 4093 ? strlen(name) : 4093;
+		memcpy(buff, name, name_len);
+
+		buff[name_len] = '_';
+		buff[name_len + 1] = 'e';
+		buff[name_len + 2] = '\0';
+		struct bpf_program* prog = bpf_object__find_program_by_name(g_state.skel->obj, buff);
+		if (prog != NULL) {
+			bpf_program__set_autoload(prog, ppm_sc_of_interest[i]);
+		}
+
+		buff[name_len + 1] = 'x';
+		prog = bpf_object__find_program_by_name(g_state.skel->obj, buff);
+		if (prog != NULL) {
+			bpf_program__set_autoload(prog, ppm_sc_of_interest[i]);
+		}
+	}
+
 	return 0;
 }
 

--- a/userspace/libpman/src/programs.c
+++ b/userspace/libpman/src/programs.c
@@ -299,9 +299,9 @@ int pman_detach_signal_deliver()
 	return 0;
 }
 
-int pman_set_autoload_programs(const bool ppm_sc_of_interest[])
+int pman_set_autoload_programs(const bool ppm_sc_of_interest[PPM_SC_MAX])
 {
-	char buff[4096];
+	char buff[256];
 
 	for (unsigned int i = 0; i < PPM_SC_MAX; i++) {
 		const char* name = scap_get_ppm_sc_name(i);

--- a/userspace/libpman/src/programs.c
+++ b/userspace/libpman/src/programs.c
@@ -301,11 +301,12 @@ int pman_detach_signal_deliver()
 
 int pman_set_autoload_programs(const bool ppm_sc_of_interest[PPM_SC_MAX])
 {
-	char buff[256];
+	static const size_t BUFF_SIZE = 256;
+	char buff[BUFF_SIZE];
 
 	for (unsigned int i = 0; i < PPM_SC_MAX; i++) {
 		const char* name = scap_get_ppm_sc_name(i);
-		unsigned int name_len = strlen(name) < 4093 ? strlen(name) : 4093;
+		unsigned int name_len = strlen(name) < BUFF_SIZE - 3 ? strlen(name) : BUFF_SIZE - 3;
 		memcpy(buff, name, name_len);
 
 		buff[name_len] = '_';

--- a/userspace/libscap/engine/modern_bpf/scap_modern_bpf.c
+++ b/userspace/libscap/engine/modern_bpf/scap_modern_bpf.c
@@ -174,7 +174,7 @@ static int32_t calibrate_socket_file_ops(struct scap_engine_handle engine)
 	 */
 	pid_t scap_tid = syscall(__NR_gettid);
 	pman_set_scap_tid(scap_tid);
-	
+
 	/* We just need to enable the socket syscall for the socket calibration */
 	engine.m_handle->curr_sc_set.ppm_sc[PPM_SC_SOCKET] = 1;
 	if(scap_modern_bpf__start_capture(engine) != SCAP_SUCCESS)
@@ -274,8 +274,9 @@ int32_t scap_modern_bpf__init(scap_t* handle, scap_open_args* oargs)
 	ret = pman_open_probe();
 	ret = ret ?: pman_prepare_ringbuf_array_before_loading();
 	ret = ret ?: pman_prepare_maps_before_loading();
+	ret = ret ?: pman_set_autoload_programs(oargs->ppm_sc_of_interest.ppm_sc);
 	ret = ret ?: pman_load_probe();
-	ret = ret ?: pman_finalize_maps_after_loading();
+	ret = ret ?: pman_finalize_maps_after_loading(oargs->ppm_sc_of_interest.ppm_sc);
 	ret = ret ?: pman_finalize_ringbuf_array_after_loading();
 	if(ret != SCAP_SUCCESS)
 	{


### PR DESCRIPTION
This is a small-ish change that makes it so tracepoints associated to syscalls that are not interesting will not be loaded. With this change, we can decide to exclude a tracepoint at runtime, for instance to work around a verifier issue.

It should probably be easy to upstream the change, but I already have a pending PR, so I might do that at a later point in time.