### PR TITLE
fix(libpman): avoid truncated verifier logs

### DIFF
--- a/userspace/libpman/src/lifecycle.c
+++ b/userspace/libpman/src/lifecycle.c
@@ -70,6 +70,13 @@ int pman_load_probe()
 		return errno;
 	}
 	pman_save_attached_progs();
+	// Programs are loaded so we passed the verifier we can free the 16 MB
+	if(g_state.log_buf)
+	{
+		free(g_state.log_buf);
+		g_state.log_buf = NULL;
+		g_state.log_buf_size = 0;
+	}
 	return 0;
 }
 

--- a/userspace/libpman/src/state.h
+++ b/userspace/libpman/src/state.h
@@ -32,6 +32,9 @@ limitations under the License.
 /* Pay attention this need to be bumped every time we add a new bpf program that is directly attached into the kernel */
 #define MODERN_BPF_PROG_ATTACHED_MAX 9
 
+#define BPF_LOG_BIG_BUF_SIZE (UINT32_MAX >> 8) /* Recommended log buffer size, taken from libbpf. Used for verifier logs */
+#define BPF_LOG_SMALL_BUF_SIZE 8192 /* Used for libbpf non-verifier logs */
+
 struct metrics_v2;
 
 struct internal_state
@@ -58,7 +61,8 @@ struct internal_state
 								     collect stats */
 	uint16_t n_attached_progs;				  /* number of attached progs */
 	struct metrics_v2* stats;				  /* array of stats collected by libpman */
-
+	char* log_buf; /* buffer used to store logs before sending them to the log_fn */
+	size_t log_buf_size; /* size of the log buffer */
 	falcosecurity_log_fn log_fn;
 };
 


### PR DESCRIPTION
This is a cherry-pick of [f286ecb5](https://github.com/falcosecurity/libs/commit/f286ecb5999df44f517a2cd4e0175597049d9ab3), adding better handling of verifier errors so the logs don't get truncated.