### PR TITLE
Fix sendmmsg and recvmmsg tracepoints compilation

### DIFF
--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/recvmmsg.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/recvmmsg.bpf.c
@@ -75,7 +75,7 @@ static long handle_exit(uint32_t index, void *ctx) {
 	 * have in the buffer.
 	 */
 	uint16_t snaplen = maps__get_snaplen();
-	apply_dynamic_snaplen(data->regs, &snaplen, true, NULL);
+	apply_dynamic_snaplen(data->regs, &snaplen, true, PPME_SOCKET_RECVMMSG_X);
 	if(snaplen > mmh.msg_len) {
 		snaplen = mmh.msg_len;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/sendmmsg.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/sendmmsg.bpf.c
@@ -78,7 +78,7 @@ static long handle_exit(uint32_t index, void *ctx) {
 	 * the return value if the syscall is successful.
 	 */
 	uint16_t snaplen = maps__get_snaplen();
-	apply_dynamic_snaplen(data->regs, &snaplen, true, NULL);
+	apply_dynamic_snaplen(data->regs, &snaplen, true, PPME_SOCKET_SENDMMSG_X);
 	if(mmh.msg_len > 0 && snaplen > mmh.msg_len) {
 		snaplen = mmh.msg_len;
 	}


### PR DESCRIPTION
The definition of `apply_dynamic_snaplen` has changed upstream, so we need to adapt to it.