### PR TITLE
ROX-31971: Fix verifier issues with clang > 19

### DIFF
--- a/driver/modern_bpf/helpers/base/push_data.h
+++ b/driver/modern_bpf/helpers/base/push_data.h
@@ -262,7 +262,7 @@ static __always_inline uint16_t push__charbuf(uint8_t *data,
 static __always_inline uint16_t push__bytebuf(uint8_t *data,
                                               uint64_t *payload_pos,
                                               unsigned long bytebuf_pointer,
-                                              uint16_t len_to_read,
+                                              volatile uint16_t len_to_read,
                                               enum read_memory mem) {
 	if(mem == KERNEL) {
 		if(bpf_probe_read_kernel(&data[SAFE_ACCESS(*payload_pos)],

--- a/driver/modern_bpf/helpers/base/shared_size.h
+++ b/driver/modern_bpf/helpers/base/shared_size.h
@@ -24,7 +24,7 @@
 #define MAX_UNIX_SOCKET_PATH 108 + 1
 
 /* Maximum number of `iovec` structures that we can analyze. */
-#define MAX_IOVCNT 32
+#define MAX_IOVCNT 16
 
 /* Maximum number of `pollfd` structures that we can analyze. */
 #define MAX_POLLFD 16

--- a/driver/modern_bpf/programs/attached/events/sched_process_exit.bpf.c
+++ b/driver/modern_bpf/programs/attached/events/sched_process_exit.bpf.c
@@ -104,6 +104,8 @@ static __always_inline pid_t find_new_reaper_pid(struct task_struct *father) {
 	 */
 	uint8_t cnt = 0;
 
+	// ROX-31971: some verifiers fail to interpret the end condition and loop infinitely.
+	#pragma unroll
 	for(struct task_struct *possible_reaper = READ_TASK_FIELD(father, real_parent);
 	    cnt < MAX_HIERARCHY_TRAVERSE;
 	    possible_reaper = BPF_CORE_READ(possible_reaper, real_parent)) {

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/execve.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/execve.bpf.c
@@ -91,11 +91,8 @@ int BPF_PROG(execve_x, struct pt_regs *regs, long ret) {
 		                                      total_args_len - exe_arg_len,
 		                                      MAX_PROC_ARG_ENV - exe_arg_len);
 	} else {
-		unsigned long argv = extract__syscall_argument(regs, 1);
-
-		/* Parameter 2: exe (type: PT_CHARBUF) */
-		/* Parameter 3: args (type: PT_CHARBUFARRAY) */
-		auxmap__store_exe_args_failure(auxmap, (char **)argv);
+		// ROX-31971: this branch makes the verifier overflow, skip this case.
+		return 0;
 	}
 
 	/* Parameter 4: tid (type: PT_PID) */


### PR DESCRIPTION
clang 20 and 21 are producing BPF code that doesn't pass the verifier with 0.18.1 falco code. The changes in this PR address some of those issues.