### PR TITLE
Fix crash in execve filename parameter parsing

### DIFF
--- a/driver/modern_bpf/helpers/base/maps_getters.h
+++ b/driver/modern_bpf/helpers/base/maps_getters.h
@@ -198,19 +198,13 @@ static __always_inline struct auxiliary_map *maps__get_auxiliary_map() {
 		return auxmap;
 	}
 
-	/* First event for this task (or the entry was evicted from the LRU): we
-	 * need to create the entry. `bpf_map_update_elem` requires a value to
-	 * copy from; use the single-element init template (a 128 KB value cannot
-	 * live on the BPF stack). The auxmap does not need to be zeroed (the
-	 * header, payload_pos and lengths_pos are set explicitly by
-	 * auxmap__preload_event_header, and param data is written before it is
-	 * read), so the template contents are irrelevant. */
 	uint32_t zero = 0;
 	struct auxiliary_map *init =
 	        (struct auxiliary_map *)bpf_map_lookup_elem(&auxiliary_map_init, &zero);
 	if(!init) {
 		return NULL;
 	}
+
 	if(bpf_map_update_elem(&auxiliary_maps, &pid_tgid, init, BPF_ANY)) {
 		return NULL;
 	}

--- a/driver/modern_bpf/helpers/base/maps_getters.h
+++ b/driver/modern_bpf/helpers/base/maps_getters.h
@@ -184,8 +184,37 @@ static __always_inline uint16_t maps__get_ppm_sc(uint16_t syscall_id) {
 /*=============================== AUXILIARY MAPS ===========================*/
 
 static __always_inline struct auxiliary_map *maps__get_auxiliary_map() {
-	uint32_t cpu_id = (uint32_t)bpf_get_smp_processor_id();
-	return (struct auxiliary_map *)bpf_map_lookup_elem(&auxiliary_maps, &cpu_id);
+	/* Key by `pid_tgid` rather than CPU: BPF programs are preemptible on
+	 * kernels >= 5.11, so a per-CPU scratch buffer can be clobbered by
+	 * another program scheduled on the same CPU. A task only ever runs on
+	 * one CPU at a time, so `pid_tgid` uniquely identifies an in-flight
+	 * event build (stable across the tail-call chain). See
+	 * falcosecurity/libs#2719.
+	 */
+	uint64_t pid_tgid = bpf_get_current_pid_tgid();
+	struct auxiliary_map *auxmap =
+	        (struct auxiliary_map *)bpf_map_lookup_elem(&auxiliary_maps, &pid_tgid);
+	if(auxmap) {
+		return auxmap;
+	}
+
+	/* First event for this task (or the entry was evicted from the LRU): we
+	 * need to create the entry. `bpf_map_update_elem` requires a value to
+	 * copy from; use the single-element init template (a 128 KB value cannot
+	 * live on the BPF stack). The auxmap does not need to be zeroed (the
+	 * header, payload_pos and lengths_pos are set explicitly by
+	 * auxmap__preload_event_header, and param data is written before it is
+	 * read), so the template contents are irrelevant. */
+	uint32_t zero = 0;
+	struct auxiliary_map *init =
+	        (struct auxiliary_map *)bpf_map_lookup_elem(&auxiliary_map_init, &zero);
+	if(!init) {
+		return NULL;
+	}
+	if(bpf_map_update_elem(&auxiliary_maps, &pid_tgid, init, BPF_ANY)) {
+		return NULL;
+	}
+	return (struct auxiliary_map *)bpf_map_lookup_elem(&auxiliary_maps, &pid_tgid);
 }
 
 /*=============================== AUXILIARY MAPS ===========================*/

--- a/driver/modern_bpf/helpers/base/maps_getters.h
+++ b/driver/modern_bpf/helpers/base/maps_getters.h
@@ -183,6 +183,11 @@ static __always_inline uint16_t maps__get_ppm_sc(uint16_t syscall_id) {
 
 /*=============================== AUXILIARY MAPS ===========================*/
 
+static __always_inline struct auxiliary_map *maps__lookup_auxiliary_map() {
+	uint64_t pid_tgid = bpf_get_current_pid_tgid();
+	return (struct auxiliary_map *)bpf_map_lookup_elem(&auxiliary_maps, &pid_tgid);
+}
+
 static __always_inline struct auxiliary_map *maps__get_auxiliary_map() {
 	/* Key by `pid_tgid` rather than CPU: BPF programs are preemptible on
 	 * kernels >= 5.11, so a per-CPU scratch buffer can be clobbered by
@@ -192,8 +197,7 @@ static __always_inline struct auxiliary_map *maps__get_auxiliary_map() {
 	 * falcosecurity/libs#2719.
 	 */
 	uint64_t pid_tgid = bpf_get_current_pid_tgid();
-	struct auxiliary_map *auxmap =
-	        (struct auxiliary_map *)bpf_map_lookup_elem(&auxiliary_maps, &pid_tgid);
+	struct auxiliary_map *auxmap = maps__lookup_auxiliary_map();
 	if(auxmap) {
 		return auxmap;
 	}
@@ -208,17 +212,16 @@ static __always_inline struct auxiliary_map *maps__get_auxiliary_map() {
 	if(bpf_map_update_elem(&auxiliary_maps, &pid_tgid, init, BPF_ANY)) {
 		return NULL;
 	}
-	return (struct auxiliary_map *)bpf_map_lookup_elem(&auxiliary_maps, &pid_tgid);
+	return maps__lookup_auxiliary_map();
 }
 
 /**
  * @brief Release the current task's auxiliary map entry.
  *
  * Called once an event has been submitted (best effort). Freeing the entry
- * immediately keeps the `auxiliary_maps` LRU hash populated only with events
+ * immediately keeps the `auxiliary_maps` hash populated only with events
  * that are currently being built (bounded by the CPU count), rather than one
- * entry per task that has ever produced an event. Entries left behind by
- * abandoned events (e.g. a failed tail call) are reclaimed by LRU eviction.
+ * entry per task that has ever produced an event.
  */
 static __always_inline void maps__release_auxiliary_map() {
 	uint64_t pid_tgid = bpf_get_current_pid_tgid();

--- a/driver/modern_bpf/helpers/base/maps_getters.h
+++ b/driver/modern_bpf/helpers/base/maps_getters.h
@@ -188,8 +188,7 @@ static __always_inline struct auxiliary_map *maps__get_auxiliary_map() {
 	 * kernels >= 5.11, so a per-CPU scratch buffer can be clobbered by
 	 * another program scheduled on the same CPU. A task only ever runs on
 	 * one CPU at a time, so `pid_tgid` uniquely identifies an in-flight
-	 * event build (stable across the tail-call chain). The map must not evict
-	 * entries while their owner may still be preempted. See
+	 * event build (stable across the tail-call chain). See
 	 * falcosecurity/libs#2719.
 	 */
 	uint64_t pid_tgid = bpf_get_current_pid_tgid();
@@ -216,9 +215,10 @@ static __always_inline struct auxiliary_map *maps__get_auxiliary_map() {
  * @brief Release the current task's auxiliary map entry.
  *
  * Called once an event has been submitted (best effort). Freeing the entry
- * immediately keeps the `auxiliary_maps` hash populated only with events
+ * immediately keeps the `auxiliary_maps` LRU hash populated only with events
  * that are currently being built (bounded by the CPU count), rather than one
- * entry per task that has ever produced an event.
+ * entry per task that has ever produced an event. Entries left behind by
+ * abandoned events (e.g. a failed tail call) are reclaimed by LRU eviction.
  */
 static __always_inline void maps__release_auxiliary_map() {
 	uint64_t pid_tgid = bpf_get_current_pid_tgid();

--- a/driver/modern_bpf/helpers/base/maps_getters.h
+++ b/driver/modern_bpf/helpers/base/maps_getters.h
@@ -217,6 +217,20 @@ static __always_inline struct auxiliary_map *maps__get_auxiliary_map() {
 	return (struct auxiliary_map *)bpf_map_lookup_elem(&auxiliary_maps, &pid_tgid);
 }
 
+/**
+ * @brief Release the current task's auxiliary map entry.
+ *
+ * Called once an event has been submitted (best effort). Freeing the entry
+ * immediately keeps the `auxiliary_maps` LRU hash populated only with events
+ * that are currently being built (bounded by the CPU count), rather than one
+ * entry per task that has ever produced an event. Entries left behind by
+ * abandoned events (e.g. a failed tail call) are reclaimed by LRU eviction.
+ */
+static __always_inline void maps__release_auxiliary_map() {
+	uint64_t pid_tgid = bpf_get_current_pid_tgid();
+	bpf_map_delete_elem(&auxiliary_maps, &pid_tgid);
+}
+
 /*=============================== AUXILIARY MAPS ===========================*/
 
 /*=============================== COUNTER MAPS ===========================*/

--- a/driver/modern_bpf/helpers/base/maps_getters.h
+++ b/driver/modern_bpf/helpers/base/maps_getters.h
@@ -188,7 +188,8 @@ static __always_inline struct auxiliary_map *maps__get_auxiliary_map() {
 	 * kernels >= 5.11, so a per-CPU scratch buffer can be clobbered by
 	 * another program scheduled on the same CPU. A task only ever runs on
 	 * one CPU at a time, so `pid_tgid` uniquely identifies an in-flight
-	 * event build (stable across the tail-call chain). See
+	 * event build (stable across the tail-call chain). The map must not evict
+	 * entries while their owner may still be preempted. See
 	 * falcosecurity/libs#2719.
 	 */
 	uint64_t pid_tgid = bpf_get_current_pid_tgid();
@@ -215,10 +216,9 @@ static __always_inline struct auxiliary_map *maps__get_auxiliary_map() {
  * @brief Release the current task's auxiliary map entry.
  *
  * Called once an event has been submitted (best effort). Freeing the entry
- * immediately keeps the `auxiliary_maps` LRU hash populated only with events
+ * immediately keeps the `auxiliary_maps` hash populated only with events
  * that are currently being built (bounded by the CPU count), rather than one
- * entry per task that has ever produced an event. Entries left behind by
- * abandoned events (e.g. a failed tail call) are reclaimed by LRU eviction.
+ * entry per task that has ever produced an event.
  */
 static __always_inline void maps__release_auxiliary_map() {
 	uint64_t pid_tgid = bpf_get_current_pid_tgid();

--- a/driver/modern_bpf/helpers/base/maps_getters.h
+++ b/driver/modern_bpf/helpers/base/maps_getters.h
@@ -209,7 +209,7 @@ static __always_inline struct auxiliary_map *maps__get_auxiliary_map() {
 		return NULL;
 	}
 
-	if(bpf_map_update_elem(&auxiliary_maps, &pid_tgid, init, BPF_ANY)) {
+	if(bpf_map_update_elem(&auxiliary_maps, &pid_tgid, init, BPF_NOEXIST)) {
 		return NULL;
 	}
 	return maps__lookup_auxiliary_map();

--- a/driver/modern_bpf/helpers/store/auxmap_store_params.h
+++ b/driver/modern_bpf/helpers/store/auxmap_store_params.h
@@ -60,12 +60,16 @@
 ////////////////////////////////
 
 /**
- * @brief Get the auxiliary map pointer for the current CPU.
+ * @brief Get or create the auxiliary map pointer for the current task.
  *
  * @return pointer to the auxmap
  */
 static __always_inline struct auxiliary_map *auxmap__get() {
 	return maps__get_auxiliary_map();
+}
+
+static __always_inline struct auxiliary_map *auxmap__lookup() {
+	return maps__lookup_auxiliary_map();
 }
 
 /////////////////////////////////

--- a/driver/modern_bpf/helpers/store/auxmap_store_params.h
+++ b/driver/modern_bpf/helpers/store/auxmap_store_params.h
@@ -124,12 +124,12 @@ static __always_inline void auxmap__submit_event(struct auxiliary_map *auxmap) {
 		/* This should never happen in tail-called exit programs because we check it in `sys_exit`
 		 * dispatcher. It can happen in TOCTOU mitigation programs. */
 		bpf_printk("FAILURE: unable to obtain the ring buffer");
-		return;
+		goto out;
 	}
 
 	struct counter_map *counter = maps__get_counter_map();
 	if(!counter) {
-		return;
+		goto out;
 	}
 
 	/* This counts the event seen by the drivers even if they are dropped because the buffer is
@@ -138,7 +138,7 @@ static __always_inline void auxmap__submit_event(struct auxiliary_map *auxmap) {
 
 	if(auxmap->payload_pos > MAX_EVENT_SIZE) {
 		counter->n_drops_max_event_size++;
-		return;
+		goto out;
 	}
 
 	/* `BPF_RB_NO_WAKEUP` means that we don't send to userspace a notification
@@ -153,6 +153,7 @@ static __always_inline void auxmap__submit_event(struct auxiliary_map *auxmap) {
 	/* The event has been handed to the ring buffer (or dropped); release this
 	 * task's auxiliary map entry so the LRU hash is not filled with one entry
 	 * per task that has ever produced an event. See falcosecurity/libs#2719. */
+out:
 	maps__release_auxiliary_map();
 	return;
 }

--- a/driver/modern_bpf/helpers/store/auxmap_store_params.h
+++ b/driver/modern_bpf/helpers/store/auxmap_store_params.h
@@ -149,6 +149,11 @@ static __always_inline void auxmap__submit_event(struct auxiliary_map *auxmap) {
 		counter->n_drops_buffer++;
 		compute_event_types_stats(auxmap->event_type, counter);
 	}
+
+	/* The event has been handed to the ring buffer (or dropped); release this
+	 * task's auxiliary map entry so the LRU hash is not filled with one entry
+	 * per task that has ever produced an event. See falcosecurity/libs#2719. */
+	maps__release_auxiliary_map();
 	return;
 }
 

--- a/driver/modern_bpf/helpers/store/ringbuf_store_params.h
+++ b/driver/modern_bpf/helpers/store/ringbuf_store_params.h
@@ -294,7 +294,7 @@ static __always_inline void ringbuf__store_u64(struct ringbuf_struct *ringbuf, u
 /**
  * @brief Store the size of a message extracted from an `iovec` struct array.
  *
- * @param auxmap pointer to the ringbuf in which we are storing the param.
+ * @param ringbuf pointer to the ringbuf in which we are storing the param.
  * @param iov_pointer pointer to `iovec` struct array.
  * @param iov_cnt number of `iovec` structs to be read from userspace.
  */
@@ -302,8 +302,7 @@ static __always_inline void ringbuf__store_iovec_size_param(struct ringbuf_struc
                                                             unsigned long iov_pointer,
                                                             unsigned long iov_cnt) {
 	/* The idea here is to use the auxmap of this CPU as a scratch space
-	 * and normally use the ringbuf to send data to userspace. Note that
-	 * we are running on this CPU so nobody else can use the auxmap in the meanwhile.
+	 * and normally use the ringbuf to send data to userspace.
 	 * Here we don't have to use the second half of the map, we can use all the space
 	 * we want since we will never use the map to send data to userspace!
 	 */
@@ -325,6 +324,7 @@ static __always_inline void ringbuf__store_iovec_size_param(struct ringbuf_struc
 	                       SAFE_ACCESS(total_iovec_size),
 	                       (void *)iov_pointer)) {
 		ringbuf__store_u32(ringbuf, 0);
+		maps__release_auxiliary_map();
 		return;
 	}
 
@@ -349,4 +349,5 @@ static __always_inline void ringbuf__store_iovec_size_param(struct ringbuf_struc
 		}
 	}
 	ringbuf__store_u32(ringbuf, total_size_to_read);
+	maps__release_auxiliary_map();
 }

--- a/driver/modern_bpf/maps/maps.h
+++ b/driver/modern_bpf/maps/maps.h
@@ -144,15 +144,40 @@ struct {
  */
 
 /**
- * @brief For every CPU on the system we have an auxiliary
- * map where the event is temporally saved before being
+ * @brief Auxiliary map where the event is temporally saved before being
  * pushed in the ringbuffer.
+ *
+ * This is keyed by `pid_tgid` (not CPU) and backed by an LRU hash to avoid a
+ * data-corruption race on preemptible kernels (Linux >= 5.11). BPF programs run
+ * with `migrate_disable()` but are preemptible: a per-CPU scratch buffer can be
+ * clobbered if a program is preempted mid-write and another program runs on the
+ * same CPU. Keying by `pid_tgid` gives each in-flight task its own scratch
+ * entry, since a task can only run on one CPU at a time. See
+ * falcosecurity/libs#2719.
+ */
+struct {
+	__uint(type, BPF_MAP_TYPE_LRU_HASH);
+	__type(key, uint64_t);
+	__type(value, struct auxiliary_map);
+} auxiliary_maps __weak SEC(".maps");
+
+/**
+ * @brief Single-element template used to initialise a new `auxiliary_maps`
+ * entry.
+ *
+ * `bpf_map_update_elem` on the LRU hash requires a source value to copy from
+ * when creating a new entry for a task. We cannot build a 128 KB value on the
+ * BPF stack (512 byte limit), so we keep one element to copy from. Its contents
+ * are irrelevant (the auxmap is always written before it is read), so it is
+ * never explicitly initialised. A regular ARRAY is used because a
+ * BPF_MAP_TYPE_PERCPU_ARRAY element is limited to 32 KB.
  */
 struct {
 	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(max_entries, 1);
 	__type(key, uint32_t);
 	__type(value, struct auxiliary_map);
-} auxiliary_maps __weak SEC(".maps");
+} auxiliary_map_init __weak SEC(".maps");
 
 /**
  * @brief For every CPU on the system we have a counter

--- a/driver/modern_bpf/maps/maps.h
+++ b/driver/modern_bpf/maps/maps.h
@@ -147,16 +147,17 @@ struct {
  * @brief Auxiliary map where the event is temporally saved before being
  * pushed in the ringbuffer.
  *
- * This is keyed by `pid_tgid` (not CPU) and backed by an LRU hash to avoid a
+ * This is keyed by `pid_tgid` (not CPU) and backed by a hash map to avoid a
  * data-corruption race on preemptible kernels (Linux >= 5.11). BPF programs run
  * with `migrate_disable()` but are preemptible: a per-CPU scratch buffer can be
  * clobbered if a program is preempted mid-write and another program runs on the
  * same CPU. Keying by `pid_tgid` gives each in-flight task its own scratch
- * entry, since a task can only run on one CPU at a time. See
+ * entry, since a task can only run on one CPU at a time. Entries must not be
+ * evicted while a preempted program still holds a pointer to them. See
  * falcosecurity/libs#2719.
  */
 struct {
-	__uint(type, BPF_MAP_TYPE_LRU_HASH);
+	__uint(type, BPF_MAP_TYPE_HASH);
 	__type(key, uint64_t);
 	__type(value, struct auxiliary_map);
 } auxiliary_maps __weak SEC(".maps");

--- a/driver/modern_bpf/maps/maps.h
+++ b/driver/modern_bpf/maps/maps.h
@@ -147,17 +147,16 @@ struct {
  * @brief Auxiliary map where the event is temporally saved before being
  * pushed in the ringbuffer.
  *
- * This is keyed by `pid_tgid` (not CPU) and backed by a hash map to avoid a
+ * This is keyed by `pid_tgid` (not CPU) and backed by an LRU hash to avoid a
  * data-corruption race on preemptible kernels (Linux >= 5.11). BPF programs run
  * with `migrate_disable()` but are preemptible: a per-CPU scratch buffer can be
  * clobbered if a program is preempted mid-write and another program runs on the
  * same CPU. Keying by `pid_tgid` gives each in-flight task its own scratch
- * entry, since a task can only run on one CPU at a time. Entries must not be
- * evicted while a preempted program still holds a pointer to them. See
+ * entry, since a task can only run on one CPU at a time. See
  * falcosecurity/libs#2719.
  */
 struct {
-	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(type, BPF_MAP_TYPE_LRU_HASH);
 	__type(key, uint64_t);
 	__type(value, struct auxiliary_map);
 } auxiliary_maps __weak SEC(".maps");

--- a/driver/modern_bpf/maps/maps.h
+++ b/driver/modern_bpf/maps/maps.h
@@ -147,16 +147,17 @@ struct {
  * @brief Auxiliary map where the event is temporally saved before being
  * pushed in the ringbuffer.
  *
- * This is keyed by `pid_tgid` (not CPU) and backed by an LRU hash to avoid a
+ * This is keyed by `pid_tgid` (not CPU) and backed by a hash map to avoid a
  * data-corruption race on preemptible kernels (Linux >= 5.11). BPF programs run
  * with `migrate_disable()` but are preemptible: a per-CPU scratch buffer can be
  * clobbered if a program is preempted mid-write and another program runs on the
  * same CPU. Keying by `pid_tgid` gives each in-flight task its own scratch
- * entry, since a task can only run on one CPU at a time. See
+ * entry, since a task can only run on one CPU at a time. A full map drops a
+ * new event rather than evicting state that an in-flight tail call requires. See
  * falcosecurity/libs#2719.
  */
 struct {
-	__uint(type, BPF_MAP_TYPE_LRU_HASH);
+	__uint(type, BPF_MAP_TYPE_HASH);
 	__type(key, uint64_t);
 	__type(value, struct auxiliary_map);
 } auxiliary_maps __weak SEC(".maps");
@@ -165,7 +166,7 @@ struct {
  * @brief Single-element template used to initialise a new `auxiliary_maps`
  * entry.
  *
- * `bpf_map_update_elem` on the LRU hash requires a source value to copy from
+ * `bpf_map_update_elem` on the hash requires a source value to copy from
  * when creating a new entry for a task. We cannot build a 128 KB value on the
  * BPF stack (512 byte limit), so we keep one element to copy from. Its contents
  * are irrelevant (the auxmap is always written before it is read), so it is

--- a/driver/modern_bpf/programs/attached/events/sched_process_exec.bpf.c
+++ b/driver/modern_bpf/programs/attached/events/sched_process_exec.bpf.c
@@ -173,7 +173,7 @@ int BPF_PROG(sched_p_exec, struct task_struct *p, pid_t old_pid, struct linux_bi
 
 SEC("tp_btf/sched_process_exec")
 int BPF_PROG(t1_sched_p_exec, struct task_struct *p, pid_t old_pid, struct linux_binprm *bprm) {
-	struct auxiliary_map *auxmap = auxmap__get();
+	struct auxiliary_map *auxmap = auxmap__lookup();
 	if(!auxmap) {
 		return 0;
 	}
@@ -294,7 +294,7 @@ int BPF_PROG(t1_sched_p_exec, struct task_struct *p, pid_t old_pid, struct linux
 
 SEC("tp_btf/sched_process_exec")
 int BPF_PROG(t2_sched_p_exec, struct pt_regs *regs, long ret, struct linux_binprm *bprm) {
-	struct auxiliary_map *auxmap = auxmap__get();
+	struct auxiliary_map *auxmap = auxmap__lookup();
 	if(!auxmap) {
 		return 0;
 	}

--- a/driver/modern_bpf/programs/attached/events/sched_process_exec.bpf.c
+++ b/driver/modern_bpf/programs/attached/events/sched_process_exec.bpf.c
@@ -167,6 +167,7 @@ int BPF_PROG(sched_p_exec, struct task_struct *p, pid_t old_pid, struct linux_bi
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	bpf_tail_call(ctx, &extra_sched_proc_exec_calls, T1_SCHED_PROC_EXEC);
+	maps__release_auxiliary_map();
 	return 0;
 }
 
@@ -287,6 +288,7 @@ int BPF_PROG(t1_sched_p_exec, struct task_struct *p, pid_t old_pid, struct linux
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	bpf_tail_call(ctx, &extra_sched_proc_exec_calls, T2_SCHED_PROC_EXEC);
+	maps__release_auxiliary_map();
 	return 0;
 }
 

--- a/driver/modern_bpf/programs/attached/events/sched_process_fork.bpf.c
+++ b/driver/modern_bpf/programs/attached/events/sched_process_fork.bpf.c
@@ -160,6 +160,7 @@ int BPF_PROG(sched_p_fork, struct task_struct *parent, struct task_struct *child
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	bpf_tail_call(ctx, &extra_sched_proc_fork_calls, T1_SCHED_PROC_FORK);
+	maps__release_auxiliary_map();
 	return 0;
 }
 
@@ -238,6 +239,7 @@ int BPF_PROG(t1_sched_p_fork, struct task_struct *parent, struct task_struct *ch
 	 * for the verifier (limit 1000000 instructions).
 	 */
 	bpf_tail_call(ctx, &extra_sched_proc_fork_calls, T2_SCHED_PROC_FORK);
+	maps__release_auxiliary_map();
 	return 0;
 }
 

--- a/driver/modern_bpf/programs/attached/events/sched_process_fork.bpf.c
+++ b/driver/modern_bpf/programs/attached/events/sched_process_fork.bpf.c
@@ -166,7 +166,7 @@ int BPF_PROG(sched_p_fork, struct task_struct *parent, struct task_struct *child
 
 SEC("tp_btf/sched_process_fork")
 int BPF_PROG(t1_sched_p_fork, struct task_struct *parent, struct task_struct *child) {
-	struct auxiliary_map *auxmap = auxmap__get();
+	struct auxiliary_map *auxmap = auxmap__lookup();
 	if(!auxmap) {
 		return 0;
 	}
@@ -245,7 +245,7 @@ int BPF_PROG(t1_sched_p_fork, struct task_struct *parent, struct task_struct *ch
 
 SEC("tp_btf/sched_process_fork")
 int BPF_PROG(t2_sched_p_fork, struct task_struct *parent, struct task_struct *child) {
-	struct auxiliary_map *auxmap = auxmap__get();
+	struct auxiliary_map *auxmap = auxmap__lookup();
 	if(!auxmap) {
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/clone.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/clone.bpf.c
@@ -133,7 +133,7 @@ int BPF_PROG(clone_x, struct pt_regs *regs, long ret) {
 
 SEC("tp_btf/sys_exit")
 int BPF_PROG(t1_clone_x, struct pt_regs *regs, long ret) {
-	struct auxiliary_map *auxmap = auxmap__get();
+	struct auxiliary_map *auxmap = auxmap__lookup();
 	if(!auxmap) {
 		return 0;
 	}
@@ -190,7 +190,7 @@ int BPF_PROG(t1_clone_x, struct pt_regs *regs, long ret) {
 
 SEC("tp_btf/sys_exit")
 int BPF_PROG(t2_clone_x, struct pt_regs *regs, long ret) {
-	struct auxiliary_map *auxmap = auxmap__get();
+	struct auxiliary_map *auxmap = auxmap__lookup();
 	if(!auxmap) {
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/clone.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/clone.bpf.c
@@ -127,6 +127,7 @@ int BPF_PROG(clone_x, struct pt_regs *regs, long ret) {
 	 * for the verifier (limit 1000000 instructions).
 	 */
 	bpf_tail_call(ctx, &syscall_exit_extra_tail_table, T1_CLONE_X);
+	maps__release_auxiliary_map();
 	return 0;
 }
 
@@ -183,6 +184,7 @@ int BPF_PROG(t1_clone_x, struct pt_regs *regs, long ret) {
 	 * for the verifier (limit 1000000 instructions).
 	 */
 	bpf_tail_call(ctx, &syscall_exit_extra_tail_table, T2_CLONE_X);
+	maps__release_auxiliary_map();
 	return 0;
 }
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/clone3.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/clone3.bpf.c
@@ -127,6 +127,7 @@ int BPF_PROG(clone3_x, struct pt_regs *regs, long ret) {
 	 * for the verifier (limit 1000000 instructions).
 	 */
 	bpf_tail_call(ctx, &syscall_exit_extra_tail_table, T1_CLONE3_X);
+	maps__release_auxiliary_map();
 	return 0;
 }
 
@@ -181,6 +182,7 @@ int BPF_PROG(t1_clone3_x, struct pt_regs *regs, long ret) {
 	 * for the verifier (limit 1000000 instructions).
 	 */
 	bpf_tail_call(ctx, &syscall_exit_extra_tail_table, T2_CLONE3_X);
+	maps__release_auxiliary_map();
 	return 0;
 }
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/clone3.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/clone3.bpf.c
@@ -133,7 +133,7 @@ int BPF_PROG(clone3_x, struct pt_regs *regs, long ret) {
 
 SEC("tp_btf/sys_exit")
 int BPF_PROG(t1_clone3_x, struct pt_regs *regs, long ret) {
-	struct auxiliary_map *auxmap = auxmap__get();
+	struct auxiliary_map *auxmap = auxmap__lookup();
 	if(!auxmap) {
 		return 0;
 	}
@@ -188,7 +188,7 @@ int BPF_PROG(t1_clone3_x, struct pt_regs *regs, long ret) {
 
 SEC("tp_btf/sys_exit")
 int BPF_PROG(t2_clone3_x, struct pt_regs *regs, long ret) {
-	struct auxiliary_map *auxmap = auxmap__get();
+	struct auxiliary_map *auxmap = auxmap__lookup();
 	if(!auxmap) {
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/execve.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/execve.bpf.c
@@ -65,6 +65,7 @@ int BPF_PROG(execve_x, struct pt_regs *regs, long ret) {
 		                                      MAX_PROC_ARG_ENV - exe_arg_len);
 	} else {
 		// ROX-31971: this branch makes the verifier overflow, skip this case.
+		maps__release_auxiliary_map();
 		return 0;
 	}
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/execveat.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/execveat.bpf.c
@@ -126,6 +126,7 @@ int BPF_PROG(execveat_x, struct pt_regs *regs, long ret) {
 	 * for the verifier (limit 1000000 instructions).
 	 */
 	bpf_tail_call(ctx, &syscall_exit_extra_tail_table, T1_EXECVEAT_X);
+	maps__release_auxiliary_map();
 	return 0;
 }
 
@@ -261,6 +262,7 @@ int BPF_PROG(t1_execveat_x, struct pt_regs *regs, long ret) {
 
 	bpf_tail_call(ctx, &syscall_exit_extra_tail_table, T2_EXECVEAT_X);
 #endif
+	maps__release_auxiliary_map();
 	return 0;
 }
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fork.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fork.bpf.c
@@ -129,6 +129,7 @@ int BPF_PROG(fork_x, struct pt_regs *regs, long ret) {
 	 * for the verifier (limit 1000000 instructions).
 	 */
 	bpf_tail_call(ctx, &syscall_exit_extra_tail_table, T1_FORK_X);
+	maps__release_auxiliary_map();
 	return 0;
 }
 
@@ -175,6 +176,7 @@ int BPF_PROG(t1_fork_x, struct pt_regs *regs, long ret) {
 	 * for the verifier (limit 1000000 instructions).
 	 */
 	bpf_tail_call(ctx, &syscall_exit_extra_tail_table, T2_FORK_X);
+	maps__release_auxiliary_map();
 	return 0;
 }
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fork.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fork.bpf.c
@@ -135,7 +135,7 @@ int BPF_PROG(fork_x, struct pt_regs *regs, long ret) {
 
 SEC("tp_btf/sys_exit")
 int BPF_PROG(t1_fork_x, struct pt_regs *regs, long ret) {
-	struct auxiliary_map *auxmap = auxmap__get();
+	struct auxiliary_map *auxmap = auxmap__lookup();
 	if(!auxmap) {
 		return 0;
 	}
@@ -182,7 +182,7 @@ int BPF_PROG(t1_fork_x, struct pt_regs *regs, long ret) {
 
 SEC("tp_btf/sys_exit")
 int BPF_PROG(t2_fork_x, struct pt_regs *regs, long ret) {
-	struct auxiliary_map *auxmap = auxmap__get();
+	struct auxiliary_map *auxmap = auxmap__lookup();
 	if(!auxmap) {
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/open_by_handle_at.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/open_by_handle_at.bpf.c
@@ -45,7 +45,7 @@ int BPF_PROG(t1_open_by_handle_at_x, struct pt_regs *regs, long ret) {
 	uint64_t ino = 0;
 	enum ppm_overlay ol = PPM_NOT_OVERLAY_FS;
 
-	struct auxiliary_map *auxmap = auxmap__get();
+	struct auxiliary_map *auxmap = auxmap__lookup();
 	if(!auxmap) {
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/open_by_handle_at.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/open_by_handle_at.bpf.c
@@ -35,6 +35,7 @@ int BPF_PROG(open_by_handle_at_x, struct pt_regs *regs, long ret) {
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	bpf_tail_call(ctx, &syscall_exit_extra_tail_table, T1_OPEN_BY_HANDLE_AT_X);
+	maps__release_auxiliary_map();
 	return 0;
 }
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/vfork.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/vfork.bpf.c
@@ -127,6 +127,7 @@ int BPF_PROG(vfork_x, struct pt_regs *regs, long ret) {
 	 * for the verifier (limit 1000000 instructions).
 	 */
 	bpf_tail_call(ctx, &syscall_exit_extra_tail_table, T1_VFORK_X);
+	maps__release_auxiliary_map();
 	return 0;
 }
 
@@ -173,6 +174,7 @@ int BPF_PROG(t1_vfork_x, struct pt_regs *regs, long ret) {
 	 * for the verifier (limit 1000000 instructions).
 	 */
 	bpf_tail_call(ctx, &syscall_exit_extra_tail_table, T2_VFORK_X);
+	maps__release_auxiliary_map();
 	return 0;
 }
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/vfork.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/vfork.bpf.c
@@ -133,7 +133,7 @@ int BPF_PROG(vfork_x, struct pt_regs *regs, long ret) {
 
 SEC("tp_btf/sys_exit")
 int BPF_PROG(t1_vfork_x, struct pt_regs *regs, long ret) {
-	struct auxiliary_map *auxmap = auxmap__get();
+	struct auxiliary_map *auxmap = auxmap__lookup();
 	if(!auxmap) {
 		return 0;
 	}
@@ -180,7 +180,7 @@ int BPF_PROG(t1_vfork_x, struct pt_regs *regs, long ret) {
 
 SEC("tp_btf/sys_exit")
 int BPF_PROG(t2_vfork_x, struct pt_regs *regs, long ret) {
-	struct auxiliary_map *auxmap = auxmap__get();
+	struct auxiliary_map *auxmap = auxmap__lookup();
 	if(!auxmap) {
 		return 0;
 	}

--- a/userspace/libpman/src/maps.c
+++ b/userspace/libpman/src/maps.c
@@ -377,8 +377,18 @@ int pman_mark_single_64bit_syscall(int syscall_id, bool interesting) {
 }
 
 static int size_auxiliary_maps() {
-	/* We always allocate auxiliary maps from all the CPUs, even if some of them are not online. */
-	if(bpf_map__set_max_entries(g_state.skel->maps.auxiliary_maps, g_state.n_possible_cpus)) {
+	/* `auxiliary_maps` is an LRU hash keyed by `pid_tgid`, holding one scratch
+	 * entry per task that is currently building an event. Only one task runs
+	 * per CPU at a time, but a task can be preempted mid-build while another
+	 * runs on the same CPU, so we need headroom above the CPU count. We size
+	 * it at 4x the possible CPUs (with a sensible floor) so that LRU eviction
+	 * of an in-flight entry is effectively impossible. If an entry were ever
+	 * evicted mid-build the event would be dropped, never corrupted. */
+	uint32_t aux_entries = g_state.n_possible_cpus * 4;
+	if(aux_entries < 128) {
+		aux_entries = 128;
+	}
+	if(bpf_map__set_max_entries(g_state.skel->maps.auxiliary_maps, aux_entries)) {
 		pman_print_error("unable to set max entries for 'auxiliary_maps'");
 		return errno;
 	}

--- a/userspace/libpman/src/maps.c
+++ b/userspace/libpman/src/maps.c
@@ -378,15 +378,15 @@ int pman_mark_single_64bit_syscall(int syscall_id, bool interesting) {
 
 static int size_auxiliary_maps() {
 	/* `auxiliary_maps` is an LRU hash keyed by `pid_tgid`, holding one scratch
-	 * entry per task that is currently building an event. Only one task runs
-	 * per CPU at a time, but a task can be preempted mid-build while another
-	 * runs on the same CPU, so we need headroom above the CPU count. We size
-	 * it at 4x the possible CPUs (with a sensible floor) so that LRU eviction
-	 * of an in-flight entry is effectively impossible. If an entry were ever
-	 * evicted mid-build the event would be dropped, never corrupted. */
-	uint32_t aux_entries = g_state.n_possible_cpus * 4;
-	if(aux_entries < 128) {
-		aux_entries = 128;
+	 * entry per event currently being built. Entries are released as soon as an
+	 * event is submitted, so at any instant the number of live entries is
+	 * bounded by the number of tasks building an event concurrently (at most
+	 * one per CPU). We size it at 2x the possible CPUs (with a small floor) to
+	 * leave headroom; the LRU reclaims any entries left behind by abandoned
+	 * events. */
+	uint32_t aux_entries = g_state.n_possible_cpus * 2;
+	if(aux_entries < 16) {
+		aux_entries = 16;
 	}
 	if(bpf_map__set_max_entries(g_state.skel->maps.auxiliary_maps, aux_entries)) {
 		pman_print_error("unable to set max entries for 'auxiliary_maps'");

--- a/userspace/libpman/src/maps.c
+++ b/userspace/libpman/src/maps.c
@@ -377,13 +377,13 @@ int pman_mark_single_64bit_syscall(int syscall_id, bool interesting) {
 }
 
 static int size_auxiliary_maps() {
-	/* `auxiliary_maps` is a hash keyed by `pid_tgid`, holding one scratch
+	/* `auxiliary_maps` is an LRU hash keyed by `pid_tgid`, holding one scratch
 	 * entry per event currently being built. Entries are released as soon as an
 	 * event is submitted, so at any instant the number of live entries is
 	 * bounded by the number of tasks building an event concurrently (at most
 	 * one per CPU). We size it at 3x the possible CPUs (with a small floor) to
-	 * leave headroom for incomplete events. A full map drops new events rather
-	 * than invalidating an event being built. */
+	 * leave headroom; the LRU reclaims any entries left behind by abandoned
+	 * events. */
 	uint32_t aux_entries = g_state.n_possible_cpus * 3;
 	if(aux_entries < 16) {
 		aux_entries = 16;

--- a/userspace/libpman/src/maps.c
+++ b/userspace/libpman/src/maps.c
@@ -381,10 +381,10 @@ static int size_auxiliary_maps() {
 	 * entry per event currently being built. Entries are released as soon as an
 	 * event is submitted, so at any instant the number of live entries is
 	 * bounded by the number of tasks building an event concurrently (at most
-	 * one per CPU). We size it at 2x the possible CPUs (with a small floor) to
+	 * one per CPU). We size it at 3x the possible CPUs (with a small floor) to
 	 * leave headroom; the LRU reclaims any entries left behind by abandoned
 	 * events. */
-	uint32_t aux_entries = g_state.n_possible_cpus * 2;
+	uint32_t aux_entries = g_state.n_possible_cpus * 3;
 	if(aux_entries < 16) {
 		aux_entries = 16;
 	}

--- a/userspace/libpman/src/maps.c
+++ b/userspace/libpman/src/maps.c
@@ -377,13 +377,13 @@ int pman_mark_single_64bit_syscall(int syscall_id, bool interesting) {
 }
 
 static int size_auxiliary_maps() {
-	/* `auxiliary_maps` is an LRU hash keyed by `pid_tgid`, holding one scratch
+	/* `auxiliary_maps` is a hash keyed by `pid_tgid`, holding one scratch
 	 * entry per event currently being built. Entries are released as soon as an
 	 * event is submitted, so at any instant the number of live entries is
 	 * bounded by the number of tasks building an event concurrently (at most
 	 * one per CPU). We size it at 3x the possible CPUs (with a small floor) to
-	 * leave headroom; the LRU reclaims any entries left behind by abandoned
-	 * events. */
+	 * leave headroom for incomplete events. A full map drops new events rather
+	 * than invalidating an event being built. */
 	uint32_t aux_entries = g_state.n_possible_cpus * 3;
 	if(aux_entries < 16) {
 		aux_entries = 16;

--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -1735,14 +1735,14 @@ void sinsp_evt_param::throw_invalid_len_error(size_t requested_length) const {
 	const scap_evt *raw = m_evt->get_scap_evt();
 	const ppm_event_info *evtinfo = m_evt->get_info();
 	if(raw && evtinfo) {
-		std::stringstream diag;
-		diag << "event diagnostics:"
+        ss.str("");
+		ss << "event diagnostics:"
 		     << " hdr_nparams=" << raw->nparams
 		     << " table_nparams=" << evtinfo->nparams
 		     << " event_len=" << raw->len
 		     << " event_type=" << raw->type
 		     << " hdr_size=" << sizeof(struct ppm_evt_hdr);
-		libsinsp_logger()->log(diag.str(), sinsp_logger::SEV_ERROR);
+		libsinsp_logger()->log(ss.str(), sinsp_logger::SEV_ERROR);
 
 		// Dump the length array from the raw event.
 		// Layout: [ppm_evt_hdr][len0][len1]...[lenN][data0][data1]...

--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -1730,6 +1730,69 @@ void sinsp_evt_param::throw_invalid_len_error(size_t requested_length) const {
 	        "parameter raw data: \n" + buffer_to_multiline_hex(param_data, param_len),
 	        sinsp_logger::SEV_ERROR);
 
+	// Enhanced diagnostics: dump raw event structure to identify the
+	// root cause of parameter corruption (ROX-33614 investigation).
+	const scap_evt *raw = m_evt->get_scap_evt();
+	const ppm_event_info *evtinfo = m_evt->get_info();
+	if(raw && evtinfo) {
+		std::stringstream diag;
+		diag << "event diagnostics:"
+		     << " hdr_nparams=" << raw->nparams
+		     << " table_nparams=" << evtinfo->nparams
+		     << " event_len=" << raw->len
+		     << " event_type=" << raw->type
+		     << " hdr_size=" << sizeof(struct ppm_evt_hdr);
+		libsinsp_logger()->log(diag.str(), sinsp_logger::SEV_ERROR);
+
+		// Dump the length array from the raw event.
+		// Layout: [ppm_evt_hdr][len0][len1]...[lenN][data0][data1]...
+		// Each length entry is uint16_t (non-large) or uint32_t (large).
+		const char *evt_base = reinterpret_cast<const char *>(raw);
+		const char *len_array = evt_base + sizeof(struct ppm_evt_hdr);
+		bool is_large = (evtinfo->flags & EF_LARGE_PAYLOAD) != 0;
+		uint32_t len_entry_size = is_large ? sizeof(uint32_t) : sizeof(uint16_t);
+		uint32_t len_array_bytes = raw->nparams * len_entry_size;
+
+		// Dump all param lengths from the raw length array.
+		std::stringstream lens;
+		lens << "raw param lengths (" << (is_large ? "large" : "u16") << "):";
+		for(uint32_t i = 0; i < raw->nparams && i < PPM_MAX_EVENT_PARAMS; i++) {
+			uint32_t plen = 0;
+			if(is_large) {
+				memcpy(&plen, len_array + i * sizeof(uint32_t), sizeof(uint32_t));
+			} else {
+				uint16_t plen16 = 0;
+				memcpy(&plen16, len_array + i * sizeof(uint16_t), sizeof(uint16_t));
+				plen = plen16;
+			}
+			lens << " [" << i << "]=" << plen;
+		}
+		libsinsp_logger()->log(lens.str(), sinsp_logger::SEV_ERROR);
+
+		// Dump the raw event header + length array as hex.
+		size_t hdr_and_lens = sizeof(struct ppm_evt_hdr) + len_array_bytes;
+		size_t dump_len = std::min(hdr_and_lens, (size_t)256);
+		libsinsp_logger()->log(
+		        "raw header+lengths (" + std::to_string(dump_len) + " bytes):\n" +
+		                buffer_to_multiline_hex(evt_base, dump_len),
+		        sinsp_logger::SEV_ERROR);
+
+		// Dump the first 128 bytes of the param data region.
+		const char *data_region = len_array + len_array_bytes;
+		size_t data_avail = 0;
+		if(raw->len > hdr_and_lens) {
+			data_avail = raw->len - hdr_and_lens;
+		}
+		size_t data_dump = std::min(data_avail, (size_t)128);
+		if(data_dump > 0) {
+			libsinsp_logger()->log(
+			        "param data region (first " + std::to_string(data_dump) +
+			                " of " + std::to_string(data_avail) + " bytes):\n" +
+			                buffer_to_multiline_hex(data_region, data_dump),
+			        sinsp_logger::SEV_ERROR);
+		}
+	}
+
 	throw sinsp_exception(error_string);
 }
 

--- a/userspace/libsinsp/event.h
+++ b/userspace/libsinsp/event.h
@@ -213,11 +213,14 @@ inline std::string_view get_event_param_as<std::string_view>(const sinsp_evt_par
 	}
 
 	size_t string_len = strnlen(param_data, param_len);
-	// We expect the parameter to be exactly one null-terminated string
+	// We expect the parameter to be exactly one null-terminated string.
+	// When it doesn't match, use the full parameter length instead.
+	// Event parameter data can have a recorded length that doesn't match
+	// the null-terminated string length. This has been observed on some
+	// kernels for both string and integer parameters (e.g. clone3 exe
+	// param_len=5 vs strnlen=1, clone flags param_len=597 vs expected 4).
 	if(param_len != string_len + 1) {
-		// By moving this error string building operation to a separate function
-		// the compiler is more likely to inline this entire function.
-		param.throw_invalid_len_error(string_len + 1);
+		string_len = param_len - 1;
 	}
 
 	return {param_data, string_len};
@@ -231,14 +234,11 @@ inline std::string get_event_param_as<std::string>(const sinsp_evt_param& param)
 	}
 
 	size_t string_len = strnlen(param_data, param_len);
-	// We expect the parameter to be exactly one null-terminated string
 	if(param_len != string_len + 1) {
-		// By moving this error string building operation to a separate function
-		// the compiler is more likely to inline this entire function.
-		param.throw_invalid_len_error(string_len + 1);
+		string_len = param_len - 1;
 	}
 
-	return std::string(param_data);
+	return std::string(param_data, string_len);
 }
 
 template<>

--- a/userspace/libsinsp/event.h
+++ b/userspace/libsinsp/event.h
@@ -213,14 +213,11 @@ inline std::string_view get_event_param_as<std::string_view>(const sinsp_evt_par
 	}
 
 	size_t string_len = strnlen(param_data, param_len);
-	// We expect the parameter to be exactly one null-terminated string.
-	// When it doesn't match, use the full parameter length instead.
-	// Event parameter data can have a recorded length that doesn't match
-	// the null-terminated string length. This has been observed on some
-	// kernels for both string and integer parameters (e.g. clone3 exe
-	// param_len=5 vs strnlen=1, clone flags param_len=597 vs expected 4).
+	// We expect the parameter to be exactly one null-terminated string
 	if(param_len != string_len + 1) {
-		string_len = param_len - 1;
+		// By moving this error string building operation to a separate function
+		// the compiler is more likely to inline this entire function.
+		param.throw_invalid_len_error(string_len + 1);
 	}
 
 	return {param_data, string_len};
@@ -234,11 +231,14 @@ inline std::string get_event_param_as<std::string>(const sinsp_evt_param& param)
 	}
 
 	size_t string_len = strnlen(param_data, param_len);
+	// We expect the parameter to be exactly one null-terminated string
 	if(param_len != string_len + 1) {
-		string_len = param_len - 1;
+		// By moving this error string building operation to a separate function
+		// the compiler is more likely to inline this entire function.
+		param.throw_invalid_len_error(string_len + 1);
 	}
 
-	return std::string(param_data, string_len);
+	return std::string(param_data);
 }
 
 template<>


### PR DESCRIPTION
On modern kernels, preemption may occur during execution of the BPF programs. In this case, the per-CPU aux map might be in an inconsistent state and result in parser failures in userspace. 

This PR attempts to use a hash, keyed on the pid_tgid to provide an auxmap per process. A hash has been chosen over an LRU because we need full control over auxmap lifetime over the course of a multi-tailcalled BPF program. With an LRU, it has been observed that eviction may happen between tail calls when preemption is high, and subsequent tailcalled programs can produce corrupted events as a result. A hash does not have this problem but provides back pressure, resulting in dropped events. This is deemed a reasonable trade off.
